### PR TITLE
feat(elixir): compiler diagnostics

### DIFF
--- a/lib/next_ls/diagnostic_cache.ex
+++ b/lib/next_ls/diagnostic_cache.ex
@@ -1,0 +1,35 @@
+defmodule NextLS.DiagnosticCache do
+  # TODO: this should be an ETS table
+  @moduledoc """
+  Cache for diagnostics.
+  """
+  use Agent
+
+  def start_link(opts) do
+    Agent.start_link(fn -> Map.new() end, Keyword.take(opts, [:name]))
+  end
+
+  def get(cache) do
+    Agent.get(cache, & &1)
+  end
+
+  def put(cache, namespace, filename, diagnostic) do
+    Agent.update(cache, fn cache ->
+      Map.update(cache, namespace, %{filename => [diagnostic]}, fn cache ->
+        Map.update(cache, filename, [diagnostic], fn v ->
+          [diagnostic | v]
+        end)
+      end)
+    end)
+  end
+
+  def clear(cache, namespace) do
+    Agent.update(cache, fn cache ->
+      Map.update(cache, namespace, %{}, fn cache ->
+        for {k, _} <- cache, into: Map.new() do
+          {k, []}
+        end
+      end)
+    end)
+  end
+end

--- a/lib/next_ls/extensions/elixir_extension.ex
+++ b/lib/next_ls/extensions/elixir_extension.ex
@@ -1,0 +1,94 @@
+defmodule NextLS.ElixirExtension do
+  use GenServer
+
+  alias NextLS.DiagnosticCache
+
+  def start_link(args) do
+    GenServer.start_link(
+      __MODULE__,
+      Keyword.take(args, [:cache, :registry, :publisher]),
+      Keyword.take(args, [:name])
+    )
+  end
+
+  @impl GenServer
+  def init(args) do
+    cache = Keyword.fetch!(args, :cache)
+    registry = Keyword.fetch!(args, :registry)
+    publisher = Keyword.fetch!(args, :publisher)
+
+    Registry.register(registry, :extension, :elixir)
+
+    {:ok, %{cache: cache, registry: registry, publisher: publisher}}
+  end
+
+  @impl GenServer
+  def handle_info({:compiler, diagnostics}, state) do
+    DiagnosticCache.clear(state.cache, :elixir)
+
+    for d <- diagnostics do
+      # TODO: some compiler diagnostics only have the line number
+      #       but we want to only highlight the source code, so we
+      #       need to read the text of the file (either from the lsp cache
+      #       if the source code is "open", or read from disk) and calculate the
+      #       column of the first non-whitespace character.
+      #
+      #       it is not clear to me whether the LSP process or the extension should
+      #       be responsible for this. The open documents live in the LSP process
+      DiagnosticCache.put(state.cache, :elixir, d.file, %GenLSP.Structures.Diagnostic{
+        severity: severity(d.severity),
+        message: d.message,
+        source: d.compiler_name,
+        range: range(d.position)
+      })
+    end
+
+    send(state.publisher, :publish)
+
+    {:noreply, state}
+  end
+
+  defp severity(:error), do: GenLSP.Enumerations.DiagnosticSeverity.error()
+  defp severity(:warning), do: GenLSP.Enumerations.DiagnosticSeverity.warning()
+  defp severity(:info), do: GenLSP.Enumerations.DiagnosticSeverity.information()
+  defp severity(:hint), do: GenLSP.Enumerations.DiagnosticSeverity.hint()
+
+  defp range({start_line, start_col, end_line, end_col}) do
+    %GenLSP.Structures.Range{
+      start: %GenLSP.Structures.Position{
+        line: start_line - 1,
+        character: start_col
+      },
+      end: %GenLSP.Structures.Position{
+        line: end_line - 1,
+        character: end_col
+      }
+    }
+  end
+
+  defp range({line, col}) do
+    %GenLSP.Structures.Range{
+      start: %GenLSP.Structures.Position{
+        line: line - 1,
+        character: col
+      },
+      end: %GenLSP.Structures.Position{
+        line: line - 1,
+        character: 999
+      }
+    }
+  end
+
+  defp range(line) do
+    %GenLSP.Structures.Range{
+      start: %GenLSP.Structures.Position{
+        line: line - 1,
+        character: 0
+      },
+      end: %GenLSP.Structures.Position{
+        line: line - 1,
+        character: 999
+      }
+    }
+  end
+end

--- a/lib/next_ls/lsp_supervisor.ex
+++ b/lib/next_ls/lsp_supervisor.ex
@@ -33,10 +33,16 @@ defmodule NextLS.LSPSupervisor do
         end
 
       children = [
-        {DynamicSupervisor, name: NextLS.RuntimeSupervisor},
+        {DynamicSupervisor, name: NextLS.DynamicSupervisor},
         {Task.Supervisor, name: NextLS.TaskSupervisor},
         {GenLSP.Buffer, buffer_opts},
-        {NextLS, task_supervisor: NextLS.TaskSupervisor, runtime_supervisor: NextLS.RuntimeSupervisor}
+        {NextLS.DiagnosticCache, [name: :diagnostic_cache]},
+        {Registry, name: NextLS.ExtensionRegistry, keys: :duplicate},
+        {NextLS,
+         cache: :diagnostic_cache,
+         task_supervisor: NextLS.TaskSupervisor,
+         dynamic_supervisor: NextLS.DynamicSupervisor,
+         extension_registry: NextLS.ExtensionRegistry}
       ]
 
       Supervisor.init(children, strategy: :one_for_one)

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -5,6 +5,8 @@ defmodule :_next_ls_private_compiler do
     # keep stdout on this node
     Process.group_leader(self(), Process.whereis(:user))
 
+    Mix.Task.clear()
+
     # load the paths for deps and compile them
     # will noop if they are already compiled
     # The mix cli basically runs this before any mix task
@@ -13,9 +15,7 @@ defmodule :_next_ls_private_compiler do
     # --no-compile, so nothing was compiled, but the
     # task was not re-enabled it seems
     Mix.Task.rerun("deps.loadpaths")
-    Mix.Task.rerun("compile")
-
-    :ok
+    Mix.Task.rerun("compile", ["--no-protocol-consolidation", "--return-errors"])
   rescue
     e -> {:error, e}
   end

--- a/test/next_ls/extensions/elixir_extension_test.exs
+++ b/test/next_ls/extensions/elixir_extension_test.exs
@@ -1,0 +1,105 @@
+defmodule NextLS.ElixirExtensionTest do
+  use ExUnit.Case, async: true
+
+  alias NextLS.ElixirExtension
+  alias NextLS.DiagnosticCache
+
+  setup do
+    cache = start_supervised!(DiagnosticCache)
+    start_supervised!({Registry, [keys: :unique, name: Registry.ElixirExtensionTest]})
+
+    extension =
+      start_supervised!({ElixirExtension, cache: cache, registry: Registry.ElixirExtensionTest, publisher: self()})
+
+    Process.link(extension)
+
+    [extension: extension, cache: cache]
+  end
+
+  test "inserts lsp diagnostics into cache", %{extension: extension, cache: cache} do
+    only_line = %Mix.Task.Compiler.Diagnostic{
+      file: "lib/bar.ex",
+      severity: :warning,
+      message: "kind of bad",
+      position: 2,
+      compiler_name: "Elixir",
+      details: nil
+    }
+
+    line_and_col = %Mix.Task.Compiler.Diagnostic{
+      file: "lib/foo.ex",
+      severity: :error,
+      message: "nothing works",
+      position: {4, 7},
+      compiler_name: "Elixir",
+      details: nil
+    }
+
+    start_and_end = %Mix.Task.Compiler.Diagnostic{
+      file: "lib/baz.ex",
+      severity: :hint,
+      message: "here's a hint",
+      position: {4, 7, 8, 3},
+      compiler_name: "Elixir",
+      details: nil
+    }
+
+    send(extension, {:compiler, [only_line, line_and_col, start_and_end]})
+
+    assert_receive :publish
+
+    assert %{
+             only_line.file => [
+               %GenLSP.Structures.Diagnostic{
+                 severity: 2,
+                 message: "kind of bad",
+                 source: "Elixir",
+                 range: %GenLSP.Structures.Range{
+                   start: %GenLSP.Structures.Position{
+                     line: 1,
+                     character: 0
+                   },
+                   end: %GenLSP.Structures.Position{
+                     line: 1,
+                     character: 999
+                   }
+                 }
+               }
+             ],
+             line_and_col.file => [
+               %GenLSP.Structures.Diagnostic{
+                 severity: 1,
+                 message: "nothing works",
+                 source: "Elixir",
+                 range: %GenLSP.Structures.Range{
+                   start: %GenLSP.Structures.Position{
+                     line: 3,
+                     character: 7
+                   },
+                   end: %GenLSP.Structures.Position{
+                     line: 3,
+                     character: 999
+                   }
+                 }
+               }
+             ],
+             start_and_end.file => [
+               %GenLSP.Structures.Diagnostic{
+                 severity: 4,
+                 message: "here's a hint",
+                 source: "Elixir",
+                 range: %GenLSP.Structures.Range{
+                   start: %GenLSP.Structures.Position{
+                     line: 3,
+                     character: 7
+                   },
+                   end: %GenLSP.Structures.Position{
+                     line: 7,
+                     character: 3
+                   }
+                 }
+               }
+             ]
+           } == DiagnosticCache.get(cache).elixir
+  end
+end

--- a/test/support/project/lib/bar.ex
+++ b/test/support/project/lib/bar.ex
@@ -1,2 +1,4 @@
 defmodule Bar do
+  def foo(arg1) do
+  end
 end


### PR DESCRIPTION
Introduce the "extension" concept and creates the ElixirExtension, which
provides Elixir compiler diagnostics.

TODO: Correct the column information on the diagnostics. I think there
are some commits on main that fix some of this. But there are Tokenizer
diagnostics that need some massaging as well.

The interface for extensions also needs to to be finalized.

Extension diagram

```mermaid
sequenceDiagram
    NextLS->>ExtensionFoo: start_child
    NextLS->>ExtensionBar: start_child
    NextLS->>NextLS.Runtime: start_child
    NextLS-->>Task.Supervisor: wait for runtime
    loop Until Runtime Ready
      Task.Supervisor->>NextLS.Runtime: ready?
      NextLS.Runtime->>Task.Supervisor: no
    end
    NextLS.Runtime->>Task.Supervisor: yes
    Task.Supervisor-->>NextLS: ready!
    NextLS-->>Task.Supervisor: ask to compile
    Task.Supervisor->>NextLS.Runtime: compile
    par Runtime to ExtensionFoo
      NextLS.Runtime->>ExtensionFoo: broadcast compiler diagnostics
      ExtensionFoo->>DiagnosticCache: put
      ExtensionFoo->>NextLS: publish1
    and Runtime to ExtensionBar
      NextLS.Runtime->>ExtensionBar: broadcast compiler diagnostics
      ExtensionBar->>DiagnosticCache: put
      ExtensionBar->>NextLS: publish2
    end
    NextLS->>Editor: PublishDiagnostics2
    NextLS->>Editor: PublishDiagnostics1
```

