### PR TITLE
fix: run compiler in task

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -53,6 +53,7 @@ defmodule NextLS do
       Keyword.split(args, [
         :cache,
         :task_supervisor,
+        :runtime_task_supervisor,
         :dynamic_supervisor,
         :extensions,
         :extension_registry,
@@ -65,6 +66,7 @@ defmodule NextLS do
   @impl true
   def init(lsp, args) do
     task_supervisor = Keyword.fetch!(args, :task_supervisor)
+    runtime_task_supervisor = Keyword.fetch!(args, :runtime_task_supervisor)
     dynamic_supervisor = Keyword.fetch!(args, :dynamic_supervisor)
     extension_registry = Keyword.fetch!(args, :extension_registry)
     extensions = Keyword.get(args, :extensions, [NextLS.ElixirExtension])
@@ -81,6 +83,7 @@ defmodule NextLS do
        logger: logger,
        symbol_table: symbol_table,
        task_supervisor: task_supervisor,
+       runtime_task_supervisor: runtime_task_supervisor,
        dynamic_supervisor: dynamic_supervisor,
        extension_registry: extension_registry,
        extensions: extensions,
@@ -272,6 +275,7 @@ defmodule NextLS do
       DynamicSupervisor.start_child(
         lsp.assigns.dynamic_supervisor,
         {NextLS.Runtime,
+         task_supervisor: lsp.assigns.runtime_task_supervisor,
          extension_registry: lsp.assigns.extension_registry,
          working_dir: working_dir,
          parent: self(),

--- a/lib/next_ls/lsp_supervisor.ex
+++ b/lib/next_ls/lsp_supervisor.ex
@@ -35,6 +35,7 @@ defmodule NextLS.LSPSupervisor do
       children = [
         {DynamicSupervisor, name: NextLS.DynamicSupervisor},
         {Task.Supervisor, name: NextLS.TaskSupervisor},
+        {Task.Supervisor, name: :runtime_task_supervisor},
         {GenLSP.Buffer, buffer_opts},
         {NextLS.DiagnosticCache, name: :diagnostic_cache},
         {NextLS.SymbolTable, name: :symbol_table, path: Path.expand(".elixir-tools")},
@@ -43,6 +44,7 @@ defmodule NextLS.LSPSupervisor do
          cache: :diagnostic_cache,
          symbol_table: :symbol_table,
          task_supervisor: NextLS.TaskSupervisor,
+         runtime_task_supervisor: :runtime_task_supervisor,
          dynamic_supervisor: NextLS.DynamicSupervisor,
          extension_registry: NextLS.ExtensionRegistry}
       ]

--- a/test/next_ls/runtime_test.exs
+++ b/test/next_ls/runtime_test.exs
@@ -41,10 +41,16 @@ defmodule NextLs.RuntimeTest do
 
   test "returns the response in an ok tuple", %{logger: logger, cwd: cwd} do
     start_supervised!({Registry, keys: :unique, name: RuntimeTestRegistry})
+    tvisor = start_supervised!(Task.Supervisor)
 
     pid =
       start_supervised!(
-        {Runtime, working_dir: cwd, parent: self(), logger: logger, extension_registry: RuntimeTestRegistry}
+        {Runtime,
+         task_supervisor: tvisor,
+         working_dir: cwd,
+         parent: self(),
+         logger: logger,
+         extension_registry: RuntimeTestRegistry}
       )
 
     Process.link(pid)
@@ -57,9 +63,16 @@ defmodule NextLs.RuntimeTest do
   test "call returns an error when the runtime is node ready", %{logger: logger, cwd: cwd} do
     start_supervised!({Registry, keys: :unique, name: RuntimeTestRegistry})
 
+    tvisor = start_supervised!(Task.Supervisor)
+
     pid =
       start_supervised!(
-        {Runtime, working_dir: cwd, parent: self(), logger: logger, extension_registry: RuntimeTestRegistry}
+        {Runtime,
+         task_supervisor: tvisor,
+         working_dir: cwd,
+         parent: self(),
+         logger: logger,
+         extension_registry: RuntimeTestRegistry}
       )
 
     Process.link(pid)
@@ -70,10 +83,17 @@ defmodule NextLs.RuntimeTest do
   test "compiles the code and returns diagnostics", %{logger: logger, cwd: cwd} do
     start_supervised!({Registry, keys: :unique, name: RuntimeTestRegistry})
 
+    tvisor = start_supervised!(Task.Supervisor)
+
     capture_log(fn ->
       pid =
         start_supervised!(
-          {Runtime, working_dir: cwd, parent: self(), logger: logger, extension_registry: RuntimeTestRegistry}
+          {Runtime,
+           task_supervisor: tvisor,
+           working_dir: cwd,
+           parent: self(),
+           logger: logger,
+           extension_registry: RuntimeTestRegistry}
         )
 
       Process.link(pid)

--- a/test/next_ls_test.exs
+++ b/test/next_ls_test.exs
@@ -869,7 +869,8 @@ defmodule NextLSTest do
   defp with_lsp(%{tmp_dir: tmp_dir}) do
     root_path = Path.absname(tmp_dir)
 
-    tvisor = start_supervised!(Task.Supervisor)
+    tvisor = start_supervised!(Supervisor.child_spec(Task.Supervisor, id: :one))
+    r_tvisor = start_supervised!(Supervisor.child_spec(Task.Supervisor, id: :two))
     rvisor = start_supervised!({DynamicSupervisor, [strategy: :one_for_one]})
     start_supervised!({Registry, [keys: :unique, name: Registry.NextLSTest]})
     extensions = [NextLS.ElixirExtension]
@@ -879,6 +880,7 @@ defmodule NextLSTest do
     server =
       server(NextLS,
         task_supervisor: tvisor,
+        runtime_task_supervisor: r_tvisor,
         dynamic_supervisor: rvisor,
         extension_registry: Registry.NextLSTest,
         extensions: extensions,


### PR DESCRIPTION
This lets the compiler stdout messgaes to be logged to the client while
the RPC is still happening.

Previously, the port would message back to the process that was
synchronously waiting on the RPC to finish, so it didn't send any log
messages to the LSP process until the compiler was done.

This made it look like the initial compiler was hanging.

Fixes #60
