### PR TITLE
feat: add hover language feature for modules and module function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Still in heavy development, currently supporting the following features:
 - Workspace Symbols
 - Document Symbols
 - Go To Definition
+- Hover
 
 ## Editor Support
 

--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -23,6 +23,7 @@ defmodule NextLS do
     TextDocumentDocumentSymbol,
     TextDocumentDefinition,
     TextDocumentFormatting,
+    TextDocumentHover,
     WorkspaceSymbol
   }
 
@@ -105,7 +106,8 @@ defmodule NextLS do
          document_formatting_provider: true,
          workspace_symbol_provider: true,
          document_symbol_provider: true,
-         definition_provider: true
+         definition_provider: true,
+         hover_provider: true
        },
        server_info: %{name: "NextLS"}
      }, assign(lsp, root_uri: root_uri)}
@@ -157,6 +159,19 @@ defmodule NextLS do
       end
 
     {:reply, symbols, lsp}
+  end
+
+  def handle_request(%TextDocumentHover{params: %{text_document: %{uri: uri}, position: position}}, lsp) do
+    hover =
+      try do
+        NextLS.Hover.fetch(lsp, lsp.assigns.documents[uri], position)
+      rescue
+        e ->
+          GenLSP.error(lsp, Exception.format_banner(:error, e, __STACKTRACE__))
+          nil
+      end
+
+    {:reply, hover, lsp}
   end
 
   def handle_request(%WorkspaceSymbol{params: %{query: query}}, lsp) do

--- a/lib/next_ls/definition.ex
+++ b/lib/next_ls/definition.ex
@@ -1,22 +1,8 @@
 defmodule NextLS.Definition do
-  def fetch(file, {line, col}, dets_symbol_table, dets_ref_table) do
-    ref =
-      :dets.select(
-        dets_ref_table,
-        [
-          {{{:"$1", {{:"$2", :"$3"}, {:"$4", :"$5"}}}, :"$6"},
-           [
-             {:andalso,
-              {:andalso, {:andalso, {:andalso, {:==, :"$1", file}, {:"=<", :"$2", line}}, {:"=<", :"$3", col}},
-               {:"=<", line, :"$4"}}, {:"=<", col, :"$5"}}
-           ], [:"$6"]}
-        ]
-      )
+  alias NextLS.ReferenceTable
 
-    # :dets.traverse(dets_symbol_table, fn x -> {:continue, x} end) |> dbg
-    # :dets.traverse(dets_ref_table, fn x -> {:continue, x} end) |> dbg
-
-    # dbg(ref)
+  def fetch(file, position, dets_symbol_table, dets_ref_table) do
+    ref = ReferenceTable.reference(dets_ref_table, file, position)
 
     query =
       case ref do

--- a/lib/next_ls/hover.ex
+++ b/lib/next_ls/hover.ex
@@ -1,0 +1,168 @@
+defmodule NextLS.Hover do
+  alias GenLSP.Structures.{
+    Hover,
+    MarkupContent,
+    Position,
+    Range
+  }
+
+  alias NextLS.Runtime
+
+  @spec fetch(lsp :: GenLSP.LSP.t(), document :: [String.t()], position :: Position.t()) :: Hover.t() | nil
+  def fetch(lsp, document, position) do
+    with {module, function, range} <- get_surround_context(document, position),
+         docs when is_binary(docs) <- fetch_docs(lsp, document, module, function) do
+      %Hover{
+        contents: %MarkupContent{
+          kind: "markdown",
+          value: docs
+        },
+        range: range
+      }
+    end
+  end
+
+  defp get_surround_context(document, position) do
+    hover_line = position.line + 1
+    hover_column = position.character + 1
+
+    case Code.Fragment.surround_context(Enum.join(document, "\n"), {hover_line, hover_column}) do
+      %{context: {:dot, {:alias, module}, function}, begin: {line, context_begin}, end: {_, context_end}} ->
+        {to_module(module), to_atom(function),
+         %Range{
+           start: %Position{line: line - 1, character: context_begin - 1},
+           end: %Position{line: line - 1, character: context_end - 1}
+         }}
+
+      %{context: {:alias, module}, begin: {line, context_begin}, end: {_, context_end}} ->
+        {to_module(module), nil,
+         %Range{
+           start: %Position{line: line - 1, character: context_begin - 1},
+           end: %Position{line: line - 1, character: context_end - 1}
+         }}
+
+      _other ->
+        nil
+    end
+  end
+
+  defp fetch_docs(lsp, document, module, function) do
+    if function do
+      with {:ok, {_, _, _, _, _, _, functions_docs}} <- request_docs(lsp, document, module),
+           {_, _, _, function_docs, _} <- find_function_docs(functions_docs, function) do
+        get_en_doc(function_docs)
+      end
+    else
+      with {:ok, {_, _, _, _, docs, _, _}} <- request_docs(lsp, document, module) do
+        get_en_doc(docs)
+      end
+    end
+  end
+
+  defp request_docs(lsp, document, module, attempt \\ 1) do
+    case send_fetch_docs_request(lsp, module) do
+      {:error, :not_ready} ->
+        nil
+
+      {:ok, {:error, :module_not_found}} ->
+        if attempt < 2 do
+          aliased_module = find_aliased_module(document, module)
+
+          if aliased_module do
+            request_docs(lsp, document, from_quoted_module_to_module(aliased_module), attempt + 1)
+          end
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp send_fetch_docs_request(lsp, module) do
+    Runtime.call(lsp.assigns.runtime, {Code, :fetch_docs, [module]})
+  end
+
+  defp find_aliased_module(document, module) do
+    module = to_quoted_module(module)
+
+    ast =
+      document
+      |> Enum.join("\n")
+      |> Code.string_to_quoted(
+        unescape: false,
+        token_metadata: true,
+        columns: true
+      )
+
+    {_ast, aliased_module} =
+      Macro.prewalk(ast, nil, fn
+        # alias A, as: B
+        {:alias, _, [{:__aliases__, _, aliased_module}, [as: {:__aliases__, _, ^module}]]} = expr, _ ->
+          {expr, aliased_module}
+
+        # alias A.{B, C}
+        {:alias, _, [{{:., _, [{:__aliases__, _, namespace}, :{}]}, _, aliases}]} = expr, acc ->
+          aliases = Enum.map(aliases, fn {:__aliases__, _, md} -> md end)
+
+          if module in aliases do
+            {expr, namespace ++ module}
+          else
+            {expr, acc}
+          end
+
+        # alias A.B.C
+        {:alias, _, [{:__aliases__, _, aliased_module}]} = expr, acc ->
+          offset = length(aliased_module) - length(module)
+
+          if Enum.slice(aliased_module, offset..-1) == module do
+            {expr, aliased_module}
+          else
+            {expr, acc}
+          end
+
+        expr, acc ->
+          {expr, acc}
+      end)
+
+    aliased_module
+  end
+
+  defp from_quoted_module_to_module(quoted_module) do
+    quoted_module
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.join(".")
+    |> to_charlist()
+    |> to_module()
+  end
+
+  defp to_module(charlist) when is_list(charlist) do
+    String.to_atom("Elixir." <> to_string(charlist))
+  end
+
+  defp to_atom(charlist) when is_list(charlist) do
+    charlist |> to_string() |> String.to_atom()
+  end
+
+  defp to_quoted_module(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.split(".")
+    |> List.delete_at(0)
+    |> Enum.map(&String.to_atom/1)
+  end
+
+  defp find_function_docs(docs, function) do
+    Enum.find(docs, fn
+      {{:function, ^function, _}, _, _, _, _} -> true
+      _ -> false
+    end)
+  end
+
+  defp get_en_doc(:none) do
+    nil
+  end
+
+  defp get_en_doc(%{"en" => doc}) do
+    doc
+  end
+end

--- a/lib/next_ls/lsp_supervisor.ex
+++ b/lib/next_ls/lsp_supervisor.ex
@@ -32,17 +32,21 @@ defmodule NextLS.LSPSupervisor do
             raise "Unknown option"
         end
 
+      path = Path.expand(".elixir-tools")
+
       children = [
         {DynamicSupervisor, name: NextLS.DynamicSupervisor},
         {Task.Supervisor, name: NextLS.TaskSupervisor},
         {Task.Supervisor, name: :runtime_task_supervisor},
         {GenLSP.Buffer, buffer_opts},
         {NextLS.DiagnosticCache, name: :diagnostic_cache},
-        {NextLS.SymbolTable, name: :symbol_table, path: Path.expand(".elixir-tools")},
+        {NextLS.SymbolTable, name: :symbol_table, path: path},
+        {NextLS.ReferenceTable, name: :reference_table, path: path},
         {Registry, name: NextLS.ExtensionRegistry, keys: :duplicate},
         {NextLS,
          cache: :diagnostic_cache,
          symbol_table: :symbol_table,
+         reference_table: :reference_table,
          task_supervisor: NextLS.TaskSupervisor,
          runtime_task_supervisor: :runtime_task_supervisor,
          dynamic_supervisor: NextLS.DynamicSupervisor,

--- a/lib/next_ls/reference_table.ex
+++ b/lib/next_ls/reference_table.ex
@@ -1,0 +1,73 @@
+defmodule NextLS.ReferenceTable do
+  @moduledoc false
+  use GenServer
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, Keyword.take(args, [:path]), Keyword.take(args, [:name]))
+  end
+
+  @spec reference(pid() | atom(), String.t(), {integer(), integer()}) :: list(struct())
+  def reference(server, file, position), do: GenServer.call(server, {:reference, file, position})
+
+  @spec put_reference(pid() | atom(), map()) :: :ok
+  def put_reference(server, reference), do: GenServer.cast(server, {:put_reference, reference})
+
+  @spec close(pid() | atom()) :: :ok | {:error, term()}
+  def close(server), do: GenServer.call(server, :close)
+
+  def init(args) do
+    path = Keyword.fetch!(args, :path)
+    reference_table_name = Keyword.get(args, :reference_table_name, :reference_table)
+
+    File.mkdir_p!(path)
+
+    {:ok, ref_name} =
+      :dets.open_file(reference_table_name,
+        file: path |> Path.join("reference_table.dets") |> String.to_charlist(),
+        type: :duplicate_bag
+      )
+
+    {:ok, %{table: ref_name}}
+  end
+
+  def handle_call({:reference, file, {line, col}}, _, state) do
+    ref =
+      :dets.select(
+        state.table,
+        [
+          {{{:"$1", {{:"$2", :"$3"}, {:"$4", :"$5"}}}, :"$6"},
+           [
+             {:andalso,
+              {:andalso, {:andalso, {:andalso, {:==, :"$1", file}, {:"=<", :"$2", line}}, {:"=<", :"$3", col}},
+               {:"=<", line, :"$4"}}, {:"=<", col, :"$5"}}
+           ], [:"$6"]}
+        ]
+      )
+
+    {:reply, ref, state}
+  end
+
+  def handle_call(:close, _, state) do
+    :dets.close(state.table)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_cast({:put_reference, reference}, state) do
+    %{
+      meta: meta,
+      identifier: identifier,
+      file: file
+    } = reference
+
+    col = meta[:column] || 0
+
+    identifier_length = identifier |> to_string() |> String.replace("Elixir.", "") |> String.length()
+
+    range = {{meta[:line], col}, {meta[:line], col + identifier_length}}
+
+    :dets.insert(state.table, {{file, range}, reference})
+
+    {:noreply, state}
+  end
+end

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -26,7 +26,7 @@ defmodule NextLSPrivate.Tracer do
 
   def trace({type, meta, module, func, arity}, env)
       when type in [:remote_function, :remote_macro, :imported_macro] and
-             module not in [:elixir_def, :elixir_utils, Kernel, Enum] do
+             module not in [:elixir_def, :elixir_utils, :elixir_module] do
     parent = parent_pid()
 
     if type == :remote_macro && meta[:closing][:line] != meta[:line] do

--- a/test/next_ls_test.exs
+++ b/test/next_ls_test.exs
@@ -934,14 +934,20 @@ defmodule NextLSTest do
 
         alias Bar.Guz
 
+        defstruct [:foo]
+
         def test do
           q1 = Atom.to_string(:atom)
           q2 = Foz.bar()
           q3 = Baz.q()
           q4 = Fiz.q()
           q5 = Guz.q()
+          q6 = to_string(:abs)
+          :timer.sleep(1)
+          a = %Example{foo: "a"}
 
-          [q1] ++ [q2] ++ [q3] ++ [q4] ++ [q5]
+
+          [q1] ++ [q2] ++ [q3] ++ [q4] ++ [q5] ++ [q6]
         end
       end
       """)
@@ -1093,7 +1099,7 @@ defmodule NextLSTest do
         id: 6,
         jsonrpc: "2.0",
         params: %{
-          position: %{line: 12, character: 9},
+          position: %{line: 14, character: 9},
           textDocument: %{uri: example_uri}
         }
       }
@@ -1105,8 +1111,8 @@ defmodule NextLSTest do
                         "value" => "Atoms are constants" <> _
                       },
                       "range" => %{
-                        "start" => %{"character" => 9, "line" => 12},
-                        "end" => %{"character" => 13, "line" => 12}
+                        "start" => %{"character" => 9, "line" => 14},
+                        "end" => %{"character" => 13, "line" => 14}
                       }
                     },
                     500
@@ -1116,7 +1122,7 @@ defmodule NextLSTest do
         id: 7,
         jsonrpc: "2.0",
         params: %{
-          position: %{line: 12, character: 22},
+          position: %{line: 14, character: 22},
           textDocument: %{uri: example_uri}
         }
       }
@@ -1128,8 +1134,8 @@ defmodule NextLSTest do
                         "value" => "Converts an atom" <> _
                       },
                       "range" => %{
-                        "start" => %{"character" => 9, "line" => 12},
-                        "end" => %{"character" => 23, "line" => 12}
+                        "start" => %{"character" => 9, "line" => 14},
+                        "end" => %{"character" => 23, "line" => 14}
                       }
                     },
                     500
@@ -1139,7 +1145,7 @@ defmodule NextLSTest do
         id: 8,
         jsonrpc: "2.0",
         params: %{
-          position: %{line: 14, character: 13},
+          position: %{line: 16, character: 13},
           textDocument: %{uri: example_uri}
         }
       }
@@ -1151,8 +1157,8 @@ defmodule NextLSTest do
                         "value" => "Bar.Baz.q function"
                       },
                       "range" => %{
-                        "start" => %{"character" => 9, "line" => 14},
-                        "end" => %{"character" => 14, "line" => 14}
+                        "start" => %{"character" => 9, "line" => 16},
+                        "end" => %{"character" => 14, "line" => 16}
                       }
                     },
                     500
@@ -1162,7 +1168,7 @@ defmodule NextLSTest do
         id: 9,
         jsonrpc: "2.0",
         params: %{
-          position: %{line: 15, character: 11},
+          position: %{line: 17, character: 11},
           textDocument: %{uri: example_uri}
         }
       }
@@ -1174,12 +1180,127 @@ defmodule NextLSTest do
         id: 10,
         jsonrpc: "2.0",
         params: %{
-          position: %{line: 15, character: 13},
+          position: %{line: 17, character: 13},
           textDocument: %{uri: example_uri}
         }
       }
 
       assert_result 10, nil, 500
+
+      request client, %{
+        method: "textDocument/hover",
+        id: 11,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 19, character: 13},
+          textDocument: %{uri: example_uri}
+        }
+      }
+
+      assert_result 11,
+                    %{
+                      "contents" => %{
+                        "kind" => "markdown",
+                        "value" => "Converts the argument to a string" <> _
+                      },
+                      "range" => %{
+                        "start" => %{"character" => 9, "line" => 19},
+                        "end" => %{"character" => 18, "line" => 19}
+                      }
+                    },
+                    500
+
+      request client, %{
+        method: "textDocument/hover",
+        id: 12,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 20, character: 7},
+          textDocument: %{uri: example_uri}
+        }
+      }
+
+      assert_result 12,
+                    %{
+                      "contents" => %{
+                        "kind" => "markdown",
+                        "value" => "\n\ttimer\n\n  This module provides useful functions related to time" <> _
+                      },
+                      "range" => %{
+                        "start" => %{"character" => 4, "line" => 20},
+                        "end" => %{"character" => 10, "line" => 20}
+                      }
+                    },
+                    500
+
+      request client, %{
+        method: "textDocument/hover",
+        id: 13,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 20, character: 13},
+          textDocument: %{uri: example_uri}
+        }
+      }
+
+      assert_result 13,
+                    %{
+                      "contents" => %{
+                        "kind" => "markdown",
+                        "value" => "\n  -spec sleep(Time) -> ok when Time :: timeout().\n\n  Suspends the process" <> _
+                      },
+                      "range" => %{
+                        "start" => %{"character" => 4, "line" => 20},
+                        "end" => %{"character" => 16, "line" => 20}
+                      }
+                    },
+                    500
+
+      request client, %{
+        method: "textDocument/hover",
+        id: 14,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 21, character: 13},
+          textDocument: %{uri: example_uri}
+        }
+      }
+
+      assert_result 14,
+                    %{
+                      "contents" => %{
+                        "kind" => "markdown",
+                        "value" => "Example doc"
+                      },
+                      "range" => %{
+                        "start" => %{"character" => 8, "line" => 21},
+                        "end" => %{"character" => 16, "line" => 21}
+                      }
+                    },
+                    500
+
+      request client, %{
+        method: "textDocument/hover",
+        id: 15,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 13, character: 3},
+          textDocument: %{uri: example_uri}
+        }
+      }
+
+      assert_result 15,
+                    %{
+                      "contents" => %{
+                        "kind" => "markdown",
+                        "value" => "Defines a public function with the given name and body" <> _
+                      },
+                      "range" => %{
+                        "start" => %{"character" => 2, "line" => 13},
+                        "end" => %{"character" => 5, "line" => 13}
+                      }
+                    },
+                    500
     end
   end
 

--- a/test/next_ls_test.exs
+++ b/test/next_ls_test.exs
@@ -944,10 +944,10 @@ defmodule NextLSTest do
           q5 = Guz.q()
           q6 = to_string(:abs)
           :timer.sleep(1)
-          a = %Example{foo: "a"}
+          q7 = %Example{foo: "a"}
 
 
-          [q1] ++ [q2] ++ [q3] ++ [q4] ++ [q5] ++ [q6]
+          [q1] ++ [q2] ++ [q3] ++ [q4] ++ [q5] ++ [q6] ++ [q7.foo]
         end
       end
       """)
@@ -979,6 +979,8 @@ defmodule NextLSTest do
         }
       }
 
+      # 1. `defmodule` macro
+
       request client, %{
         method: "textDocument/hover",
         id: 1,
@@ -1001,6 +1003,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 2. `alias` macro with :as option
 
       request client, %{
         method: "textDocument/hover",
@@ -1025,6 +1029,8 @@ defmodule NextLSTest do
                     },
                     500
 
+      # 3. `alias` macro with :as option
+
       request client, %{
         method: "textDocument/hover",
         id: 3,
@@ -1047,6 +1053,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 4. Multi `alias` macro
 
       request client, %{
         method: "textDocument/hover",
@@ -1071,6 +1079,8 @@ defmodule NextLSTest do
                     },
                     500
 
+      # 5. `alias` macro
+
       request client, %{
         method: "textDocument/hover",
         id: 5,
@@ -1093,6 +1103,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 6. Module reference
 
       request client, %{
         method: "textDocument/hover",
@@ -1117,6 +1129,8 @@ defmodule NextLSTest do
                     },
                     500
 
+      # 7. Function reference
+
       request client, %{
         method: "textDocument/hover",
         id: 7,
@@ -1131,7 +1145,9 @@ defmodule NextLSTest do
                     %{
                       "contents" => %{
                         "kind" => "markdown",
-                        "value" => "Converts an atom" <> _
+                        "value" =>
+                          "### atom_to_binary/1\n\n\n  -spec atom_to_binary(Atom) -> binary() when Atom :: atom()" <>
+                            _
                       },
                       "range" => %{
                         "start" => %{"character" => 9, "line" => 14},
@@ -1139,6 +1155,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 8. User-defined module reference
 
       request client, %{
         method: "textDocument/hover",
@@ -1154,7 +1172,7 @@ defmodule NextLSTest do
                     %{
                       "contents" => %{
                         "kind" => "markdown",
-                        "value" => "Bar.Baz.q function"
+                        "value" => "### q()\n\nBar.Baz.q function"
                       },
                       "range" => %{
                         "start" => %{"character" => 9, "line" => 16},
@@ -1162,6 +1180,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 9. User-defined module reference without doc
 
       request client, %{
         method: "textDocument/hover",
@@ -1175,6 +1195,8 @@ defmodule NextLSTest do
 
       assert_result 9, nil, 500
 
+      # 10. User-defined function reference without doc
+
       request client, %{
         method: "textDocument/hover",
         id: 10,
@@ -1186,6 +1208,8 @@ defmodule NextLSTest do
       }
 
       assert_result 10, nil, 500
+
+      # 11. Kernel function
 
       request client, %{
         method: "textDocument/hover",
@@ -1201,7 +1225,7 @@ defmodule NextLSTest do
                     %{
                       "contents" => %{
                         "kind" => "markdown",
-                        "value" => "Converts the argument to a string" <> _
+                        "value" => "### to_string(term)\n\nConverts the argument to a string" <> _
                       },
                       "range" => %{
                         "start" => %{"character" => 9, "line" => 19},
@@ -1209,6 +1233,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 12. Erlang module reference
 
       request client, %{
         method: "textDocument/hover",
@@ -1233,6 +1259,8 @@ defmodule NextLSTest do
                     },
                     500
 
+      # 13. Erlang function reference
+
       request client, %{
         method: "textDocument/hover",
         id: 13,
@@ -1247,7 +1275,9 @@ defmodule NextLSTest do
                     %{
                       "contents" => %{
                         "kind" => "markdown",
-                        "value" => "\n  -spec sleep(Time) -> ok when Time :: timeout().\n\n  Suspends the process" <> _
+                        "value" =>
+                          "### sleep/1\n\n\n  -spec sleep(Time) -> ok when Time :: timeout().\n\n  Suspends the process" <>
+                            _
                       },
                       "range" => %{
                         "start" => %{"character" => 4, "line" => 20},
@@ -1255,6 +1285,8 @@ defmodule NextLSTest do
                       }
                     },
                     500
+
+      # 14. Struct reference
 
       request client, %{
         method: "textDocument/hover",
@@ -1273,11 +1305,13 @@ defmodule NextLSTest do
                         "value" => "Example doc"
                       },
                       "range" => %{
-                        "start" => %{"character" => 8, "line" => 21},
-                        "end" => %{"character" => 16, "line" => 21}
+                        "start" => %{"character" => 9, "line" => 21},
+                        "end" => %{"character" => 17, "line" => 21}
                       }
                     },
                     500
+
+      # 15. Macro
 
       request client, %{
         method: "textDocument/hover",
@@ -1293,7 +1327,8 @@ defmodule NextLSTest do
                     %{
                       "contents" => %{
                         "kind" => "markdown",
-                        "value" => "Defines a public function with the given name and body" <> _
+                        "value" =>
+                          "### def(call, expr \\\\ nil)\n\nDefines a public function with the given name and body" <> _
                       },
                       "range" => %{
                         "start" => %{"character" => 2, "line" => 13},
@@ -1314,6 +1349,7 @@ defmodule NextLSTest do
     extensions = [NextLS.ElixirExtension]
     cache = start_supervised!(NextLS.DiagnosticCache)
     symbol_table = start_supervised!({NextLS.SymbolTable, path: tmp_dir})
+    reference_table = start_supervised!({NextLS.ReferenceTable, path: tmp_dir})
 
     server =
       server(NextLS,
@@ -1323,7 +1359,8 @@ defmodule NextLSTest do
         extension_registry: Registry.NextLSTest,
         extensions: extensions,
         cache: cache,
-        symbol_table: symbol_table
+        symbol_table: symbol_table,
+        reference_table: reference_table
       )
 
     Process.link(server.lsp)


### PR DESCRIPTION
closes #48

https://github.com/elixir-tools/next-ls/assets/929818/780eac52-a684-4106-9728-1ed6f7328521

It figures out if module or function call is hovered using `Code.Fragment.surround_context/3` and gets docs via `Code.fetch_docs/1` functions. It also supports module aliases in three forms:

What is supported:
- [x] the module from this file
- [x] aliased modules and their functions:
    - [x] Basic aliasing
    - [x] Aliasing with `:as` option
    - [x] Multi alias
- [x] `Kernel` and `Kernel.SpecialForms` functions
- [x] Erlang modules and functions
- [x] Structs
- [x] Imported module functions


