### PR TITLE
Reference lookup perf improvement and table schema versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ next_ls-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+/.elixir-tools/
+.DS_Store

--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -34,8 +34,8 @@ defmodule NextLS.Runtime do
     end
   end
 
-  def compile(server) do
-    GenServer.call(server, :compile, :infinity)
+  def compile(server, opts \\ []) do
+    GenServer.call(server, {:compile, opts}, :infinity)
   end
 
   @impl GenServer
@@ -135,10 +135,10 @@ defmodule NextLS.Runtime do
     {:reply, {:error, :not_ready}, state}
   end
 
-  def handle_call(:compile, from, %{node: node} = state) do
+  def handle_call({:compile, opts}, from, %{node: node} = state) do
     task =
       Task.Supervisor.async_nolink(state.task_supervisor, fn ->
-        {_, errors} = :rpc.call(node, :_next_ls_private_compiler, :compile, [])
+        {_, errors} = :rpc.call(node, :_next_ls_private_compiler, :compile, [opts])
 
         Registry.dispatch(state.extension_registry, :extension, fn entries ->
           for {pid, _} <- entries do

--- a/lib/next_ls/symbol_table.ex
+++ b/lib/next_ls/symbol_table.ex
@@ -102,10 +102,7 @@ defmodule NextLS.SymbolTable do
     range =
       {{meta[:line], col}, {meta[:line], col + String.length(to_string(identifier) |> String.replace("Elixir.", ""))}}
 
-    :dets.insert(state.reference_table, {
-      {file, range},
-      reference
-    })
+    :dets.insert(state.reference_table, {file, {range, reference}})
 
     {:noreply, state}
   end

--- a/lib/next_ls/symbol_table.ex
+++ b/lib/next_ls/symbol_table.ex
@@ -15,8 +15,18 @@ defmodule NextLS.SymbolTable do
           }
   end
 
-  def start_link(args) do
-    GenServer.start_link(__MODULE__, Keyword.take(args, [:path]), Keyword.take(args, [:name]))
+  @config_file_name "config.dets"
+  @symbol_table_file_name "symbol_table.dets"
+  @symbol_table_schema_version_key "symbol_table_schema_version"
+  @symbol_table_schema_version_value "0.0.1"
+  @reference_table_file_name "reference_table.dets"
+  @reference_table_schema_version_key "reference_table_schema_version"
+  @reference_table_schema_version_value "0.0.1"
+
+  def start_link(opts) do
+    init_opts = Keyword.take(opts, [:path, :config_table_name, :symbol_table_name, :reference_table_name])
+
+    GenServer.start_link(__MODULE__, init_opts, Keyword.take(opts, [:name]))
   end
 
   @spec put_symbols(pid() | atom(), list(tuple())) :: :ok
@@ -34,26 +44,28 @@ defmodule NextLS.SymbolTable do
   @spec close(pid() | atom()) :: :ok | {:error, term()}
   def close(server), do: GenServer.call(server, :close)
 
+  @spec version_changed?(pid()) :: boolean()
+  def version_changed?(server), do: GenServer.call(server, :version_changed?)
+
+  @spec flush(pid()) :: :ok
+  def flush(server), do: GenServer.cast(server, :flush)
+
+  @spec tables(pid()) :: {atom(), atom()}
+  def tables(server), do: GenServer.call(server, :tables)
+
   def init(args) do
     path = Keyword.fetch!(args, :path)
+    config_table_name = Keyword.get(args, :config_table_name, :config_table)
     symbol_table_name = Keyword.get(args, :symbol_table_name, :symbol_table)
     reference_table_name = Keyword.get(args, :reference_table_name, :reference_table)
 
     File.mkdir_p!(path)
 
-    {:ok, name} =
-      :dets.open_file(symbol_table_name,
-        file: Path.join(path, "symbol_table.dets") |> String.to_charlist(),
-        type: :duplicate_bag
-      )
+    {:ok, config} = open_file(config_table_name, Path.join(path, @config_file_name), type: :set)
+    {:ok, name} = open_symbol_file(symbol_table_name, path)
+    {:ok, ref_name} = open_reference_file(reference_table_name, path)
 
-    {:ok, ref_name} =
-      :dets.open_file(reference_table_name,
-        file: Path.join(path, "reference_table.dets") |> String.to_charlist(),
-        type: :duplicate_bag
-      )
-
-    {:ok, %{table: name, reference_table: ref_name}}
+    {:ok, %{path: path, config: config, table: name, reference_table: ref_name}}
   end
 
   def handle_call({:symbols, file}, _, state) do
@@ -84,10 +96,21 @@ defmodule NextLS.SymbolTable do
   end
 
   def handle_call(:close, _, state) do
+    :dets.close(state.config)
     :dets.close(state.table)
     :dets.close(state.reference_table)
 
     {:reply, :ok, state}
+  end
+
+  def handle_call(:version_changed?, _, state) do
+    version_changed? = symbol_version_changed?(state.config) || reference_version_changed?(state.config)
+
+    {:reply, version_changed?, state}
+  end
+
+  def handle_call(:tables, _, state) do
+    {:reply, {state.table, state.reference_table, state.config}, state}
   end
 
   def handle_cast({:put_reference, reference}, state) do
@@ -164,5 +187,49 @@ defmodule NextLS.SymbolTable do
     end
 
     {:noreply, state}
+  end
+
+  def handle_cast(:flush, state) do
+    if symbol_version_changed?(state.config) do
+      :dets.insert(state.config, {@symbol_table_schema_version_key, @symbol_table_schema_version_value})
+
+      :ok = :dets.close(state.table)
+      state.path |> Path.join(@symbol_table_file_name) |> File.rm()
+      {:ok, _} = open_symbol_file(state.table, state.path)
+    end
+
+    if reference_version_changed?(state.config) do
+      :dets.insert(state.config, {@reference_table_schema_version_key, @reference_table_schema_version_value})
+
+      :ok = :dets.close(state.reference_table)
+      state.path |> Path.join(@reference_table_file_name) |> File.rm()
+      {:ok, _} = open_reference_file(state.reference_table, state.path)
+    end
+
+    {:noreply, state}
+  end
+
+  defp open_symbol_file(name, path) do
+    open_file(name, Path.join(path, @symbol_table_file_name), type: :duplicate_bag)
+  end
+
+  defp open_reference_file(name, path) do
+    open_file(name, Path.join(path, @reference_table_file_name), type: :duplicate_bag)
+  end
+
+  defp open_file(name, path, opts) do
+    :dets.open_file(name, Keyword.merge(opts, file: String.to_charlist(path)))
+  end
+
+  defp symbol_version_changed?(config) do
+    :dets.lookup(config, @symbol_table_schema_version_key) != [
+      {@symbol_table_schema_version_key, @symbol_table_schema_version_value}
+    ]
+  end
+
+  defp reference_version_changed?(config) do
+    :dets.lookup(config, @reference_table_schema_version_key) != [
+      {@reference_table_schema_version_key, @reference_table_schema_version_value}
+    ]
   end
 end

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -114,11 +114,20 @@ end
 defmodule :_next_ls_private_compiler do
   @moduledoc false
 
-  def compile() do
+  def compile(opts) do
     # keep stdout on this node
     Process.group_leader(self(), Process.whereis(:user))
 
     Mix.Task.clear()
+
+    args = ["--no-protocol-consolidation", "--return-errors", "--tracer", "NextLSPrivate.Tracer"]
+
+    args =
+      if Keyword.get(opts, :force) do
+        ["--force" | args]
+      else
+        args
+      end
 
     # load the paths for deps and compile them
     # will noop if they are already compiled
@@ -128,7 +137,7 @@ defmodule :_next_ls_private_compiler do
     # --no-compile, so nothing was compiled, but the
     # task was not re-enabled it seems
     Mix.Task.rerun("deps.loadpaths")
-    Mix.Task.rerun("compile", ["--no-protocol-consolidation", "--return-errors", "--tracer", "NextLSPrivate.Tracer"])
+    Mix.Task.rerun("compile", args)
   rescue
     e -> {:error, e}
   end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,4 +1,7 @@
 defmodule NextLS.Support.Utils do
+  use ExUnit.Case
+
+  import GenLSP.Test
   def mix_exs do
     """
     defmodule Project.MixProject do
@@ -27,5 +30,69 @@ defmodule NextLS.Support.Utils do
       end
     end
     """
+  end
+
+  def setup_project_dir(%{tmp_dir: tmp_dir}) do
+    File.mkdir_p!(Path.join(tmp_dir, "lib"))
+    File.write!(Path.join(tmp_dir, "mix.exs"), mix_exs())
+    [cwd: tmp_dir]
+  end
+
+  def with_lsp(%{tmp_dir: tmp_dir, test: test}) do
+    root_path = Path.absname(tmp_dir)
+    server = start_lsp(tmp_dir, suffix: test)
+    client = client(server)
+
+    assert :ok ==
+             request(client, %{
+               method: "initialize",
+               id: 1,
+               jsonrpc: "2.0",
+               params: %{capabilities: %{}, rootUri: "file://#{root_path}"}
+             })
+
+    [server: server, client: client, cwd: root_path]
+  end
+
+  def uri(path) when is_binary(path) do
+    URI.to_string(%URI{
+      scheme: "file",
+      host: "",
+      path: path
+    })
+  end
+
+  def start_lsp(tmp_dir, opts \\ []) do
+    prefix = Keyword.get(opts, :prefix)
+    suffix = Keyword.get(opts, :suffix)
+
+    wrapped_name = fn name ->
+      String.to_atom("#{suffix}#{name}#{prefix}")
+    end
+
+    registry_name = wrapped_name.("registry")
+
+    tvisor = start_supervised!(Supervisor.child_spec(Task.Supervisor, id: wrapped_name.("tvisor")))
+    r_tvisor = start_supervised!(Supervisor.child_spec(Task.Supervisor, id: wrapped_name.("r_tvisor")))
+    rvisor = start_supervised!(Supervisor.child_spec({DynamicSupervisor, strategy: :one_for_one, name: wrapped_name.("rvisor")}, id: wrapped_name.("rvisor")))
+    cache = start_supervised!(Supervisor.child_spec(NextLS.DiagnosticCache, id: wrapped_name.("cache")))
+    symbol_table = start_supervised!(Supervisor.child_spec({NextLS.SymbolTable, path: tmp_dir}, id: wrapped_name.("symbol_table")))
+    start_supervised!({Registry, keys: :unique, name: registry_name})
+
+    server =
+      server(NextLS,
+        task_supervisor: tvisor,
+        runtime_task_supervisor: r_tvisor,
+        dynamic_supervisor: rvisor,
+        extension_registry: registry_name,
+        extensions: [NextLS.ElixirExtension],
+        cache: cache,
+        symbol_table: symbol_table,
+        name: wrapped_name.("server")
+      )
+
+    Process.link(server.lsp)
+
+    server
   end
 end


### PR DESCRIPTION
depends on https://github.com/elixir-tools/gen_lsp/pull/37

The fix was simple to replace `:dets.select/2` in favor of `:dets.lookup/2`. But it required a change in how references are stored. So the mechanism to clear dets table and trigger recompilation was added. It should recompile initially as the current table schema version is `nil` and every time the schema version value (for example, `@reference_table_schema_version_value`) is changed. I covered both symbol and reference tables.

This will also conflict with the hovering PR as I moved symbol logic to its own GenServer there but it should be not a big deal to resolve here or there

