### PR TITLE
feat: find references

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -173,6 +173,10 @@ defmodule NextLS do
     {:reply, symbols, lsp}
   end
 
+  # TODO extract to a separate module
+  # TODO make this work for modules and structs
+  # TODO how to handle aliases?
+  # TODO can we do this in a single DB query?
   def handle_request(%TextDocumentReferences{params: %{position: position, text_document: %{uri: uri}}} = request, lsp) do
     import NextLS.DB.Query
 

--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -182,7 +182,7 @@ defmodule NextLS do
 
     locations =
       dispatch(lsp.assigns.registry, :databases, fn databases ->
-        for {database, _} <- databases do
+        Enum.flat_map(databases, fn {database, _} ->
           references =
             case symbol_info(file, line, col, database) do
               {:function, module, function} ->
@@ -223,10 +223,10 @@ defmodule NextLS do
               }
             }
           end
-        end
+        end)
       end)
 
-    {:reply, List.flatten(locations), lsp}
+    {:reply, locations, lsp}
   end
 
   def handle_request(%WorkspaceSymbol{params: %{query: query}}, lsp) do

--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -173,6 +173,8 @@ defmodule NextLS do
     {:reply, symbols, lsp}
   end
 
+  # TODO handle `context: %{includeDeclaration: true}` to include the current symbol definition among
+  # the results.
   def handle_request(%TextDocumentReferences{params: %{position: position, text_document: %{uri: uri}}}, lsp) do
     file = URI.parse(uri).path
     line = position.line + 1

--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -694,6 +694,9 @@ defmodule NextLS do
       [[module, "defp", function]] ->
         {:function, module, function}
 
+      [[module, "defmacro", function]] ->
+        {:function, module, function}
+
       _unknown_definition ->
         case DB.query(database, reference_query, [file, line, line, col, col]) do
           [[function, "function", module]] ->

--- a/test/next_ls_test.exs
+++ b/test/next_ls_test.exs
@@ -951,8 +951,7 @@ defmodule NextLSTest do
                           "end" => %{"line" => 3, "character" => 18}
                         }
                       }
-                    ],
-                    500
+                    ]
     end
 
     test "list module references", %{client: client, bar: bar, peace: peace} do
@@ -983,8 +982,7 @@ defmodule NextLSTest do
                           "end" => %{"line" => 3, "character" => 9}
                         }
                       }
-                    ],
-                    500
+                    ]
     end
   end
 

--- a/test/next_ls_test.exs
+++ b/test/next_ls_test.exs
@@ -888,6 +888,106 @@ defmodule NextLSTest do
     end
   end
 
+  describe "find references" do
+    @describetag root_paths: ["my_proj"]
+    setup %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "my_proj/lib"))
+      File.write!(Path.join(tmp_dir, "my_proj/mix.exs"), mix_exs())
+      [cwd: tmp_dir]
+    end
+
+    setup %{cwd: cwd} do
+      peace = Path.join(cwd, "my_proj/lib/peace.ex")
+
+      File.write!(peace, """
+      defmodule MyApp.Peace do
+        def and_love() do
+          "✌️"
+        end
+      end
+      """)
+
+      bar = Path.join(cwd, "my_proj/lib/bar.ex")
+
+      File.write!(bar, """
+      defmodule Bar do
+        alias MyApp.Peace
+        def run() do
+          Peace.and_love()
+        end
+      end
+      """)
+
+      [bar: bar, peace: peace]
+    end
+
+    setup :with_lsp
+
+    test "list function references", %{client: client, bar: bar, peace: peace} do
+      assert :ok == notify(client, %{method: "initialized", jsonrpc: "2.0", params: %{}})
+      assert_request(client, "client/registerCapability", fn _params -> nil end)
+      assert_notification "window/logMessage", %{"message" => "[NextLS] Runtime for folder my_proj is ready..."}
+      assert_notification "window/logMessage", %{"message" => "[NextLS] Compiled!"}
+
+      request(client, %{
+        method: "textDocument/references",
+        id: 4,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 1, character: 6},
+          textDocument: %{uri: uri(peace)},
+          context: %{includeDeclaration: true}
+        }
+      })
+
+      uri = uri(bar)
+
+      assert_result 4,
+                    [
+                      %{
+                        "uri" => ^uri,
+                        "range" => %{
+                          "start" => %{"line" => 3, "character" => 10},
+                          "end" => %{"line" => 3, "character" => 18}
+                        }
+                      }
+                    ],
+                    500
+    end
+
+    test "list module references", %{client: client, bar: bar, peace: peace} do
+      assert :ok == notify(client, %{method: "initialized", jsonrpc: "2.0", params: %{}})
+      assert_request(client, "client/registerCapability", fn _params -> nil end)
+      assert_notification "window/logMessage", %{"message" => "[NextLS] Runtime for folder my_proj is ready..."}
+      assert_notification "window/logMessage", %{"message" => "[NextLS] Compiled!"}
+
+      request(client, %{
+        method: "textDocument/references",
+        id: 4,
+        jsonrpc: "2.0",
+        params: %{
+          position: %{line: 0, character: 10},
+          textDocument: %{uri: uri(peace)},
+          context: %{includeDeclaration: true}
+        }
+      })
+
+      uri = uri(bar)
+
+      assert_result 4,
+                    [
+                      %{
+                        "uri" => ^uri,
+                        "range" => %{
+                          "start" => %{"line" => 3, "character" => 4},
+                          "end" => %{"line" => 3, "character" => 9}
+                        }
+                      }
+                    ],
+                    500
+    end
+  end
+
   describe "workspaces" do
     setup %{tmp_dir: tmp_dir} do
       [cwd: tmp_dir]


### PR DESCRIPTION
This PR is meant to implement the [Find References Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_references).

The strategy is as follows:

1. Identify what kind of symbol we looking for
    1. Check the `symbols` table to see if we are in a definition: `defmodule`, `def`, `defp`, `defmacro` or `defstruct`
    2. If we are not in a definition, check the `references` table to see if we are in a function call or in a module alias.
2. Once we know what kind of symbol we are looking for (either a module or a function), check the `references` table to list all known references.

I've been using this today at $DAYJOB, which is a pretty big codebase, and everything seems to work just fine. I've also added two automated tests to confirm that the functionality works for finding function and module references.

Closes #43