### PR TITLE
feat(definition): go to dependency

### DIFF
--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -117,6 +117,12 @@ defmodule :_next_ls_private_compiler do
     # keep stdout on this node
     Process.group_leader(self(), Process.whereis(:user))
 
+    tracers = Code.get_compiler_option(:tracers)
+
+    tracers = Enum.uniq([NextLSPrivate.Tracer | tracers])
+
+    Code.put_compiler_option(:tracers, tracers)
+
     Mix.Task.clear()
 
     # load the paths for deps and compile them
@@ -131,9 +137,7 @@ defmodule :_next_ls_private_compiler do
     Mix.Task.rerun("compile", [
       "--ignore-module-conflict",
       "--no-protocol-consolidation",
-      "--return-errors",
-      "--tracer",
-      "NextLSPrivate.Tracer"
+      "--return-errors"
     ])
   rescue
     e -> {:error, e}


### PR DESCRIPTION
This enables the tracers when your dependencies are compiling, which adds them to the symbol table.

TODO

- [ ] Make sure that they do not show up in Workspace Symbols
- [ ] see if we need/can show the progress message when the database is finishing a "batch" of updates (message can say "indexing"). It can get bogged down and the go to def won't work until it's done inserting.
- [ ] tests
- [ ] determine feasibility for elixir source files. they won't exist on disk, and since they aren't compiled, we won't have symbols for them, but there _might_ be the possibility of opening the line of code in github in their web browser.

cc @dvic, feel free to take this over if you'd like!

Closes #91 
