### PR TITLE
feat: go to definition when aliases modules

### DIFF
--- a/lib/next_ls/ast_helpers.ex
+++ b/lib/next_ls/ast_helpers.ex
@@ -1,75 +1,151 @@
 defmodule NextLS.ASTHelpers do
   @moduledoc false
 
-  @spec get_attribute_reference_name(String.t(), integer(), integer()) :: String.t() | nil
-  def get_attribute_reference_name(file, line, column) do
-    ast = ast_from_file(file)
+  defmodule Attributes do
+    @moduledoc false
+    @spec get_attribute_reference_name(String.t(), integer(), integer()) :: String.t() | nil
+    def get_attribute_reference_name(file, line, column) do
+      ast = ast_from_file(file)
 
-    {_ast, name} =
-      Macro.prewalk(ast, nil, fn
-        {:@, [line: ^line, column: ^column], [{name, _meta, nil}]} = ast, _acc -> {ast, "@#{name}"}
-        other, acc -> {other, acc}
+      {_ast, name} =
+        Macro.prewalk(ast, nil, fn
+          {:@, [line: ^line, column: ^column], [{name, _meta, nil}]} = ast, _acc -> {ast, "@#{name}"}
+          other, acc -> {other, acc}
+        end)
+
+      name
+    end
+
+    @spec get_module_attributes(String.t(), module()) :: [{atom(), String.t(), integer(), integer()}]
+    def get_module_attributes(file, module) do
+      reserved_attributes = Module.reserved_attributes()
+
+      symbols = parse_symbols(file, module)
+
+      Enum.filter(symbols, fn
+        {:attribute, "@" <> name, _, _} ->
+          not Map.has_key?(reserved_attributes, String.to_atom(name))
+
+        _other ->
+          false
       end)
+    end
 
-    name
-  end
+    defp parse_symbols(file, module) do
+      ast = ast_from_file(file)
 
-  @spec get_module_attributes(String.t(), module()) :: [{atom(), String.t(), integer(), integer()}]
-  def get_module_attributes(file, module) do
-    reserved_attributes = Module.reserved_attributes()
+      {_ast, %{symbols: symbols}} =
+        Macro.traverse(ast, %{modules: [], symbols: []}, &prewalk/2, &postwalk(&1, &2, module))
 
-    symbols = parse_symbols(file, module)
+      symbols
+    end
 
-    Enum.filter(symbols, fn
-      {:attribute, "@" <> name, _, _} ->
-        not Map.has_key?(reserved_attributes, String.to_atom(name))
+    # add module name to modules stack on enter
+    defp prewalk({:defmodule, _, [{:__aliases__, _, module_name_atoms} | _]} = ast, acc) do
+      modules = [module_name_atoms | acc.modules]
+      {ast, %{acc | modules: modules}}
+    end
 
-      _other ->
-        false
-    end)
-  end
+    defp prewalk(ast, acc), do: {ast, acc}
 
-  defp parse_symbols(file, module) do
-    ast = ast_from_file(file)
+    defp postwalk({:@, meta, [{name, _, args}]} = ast, acc, module) when is_list(args) do
+      ast_module =
+        acc.modules
+        |> Enum.reverse()
+        |> List.flatten()
+        |> Module.concat()
 
-    {_ast, %{symbols: symbols}} =
-      Macro.traverse(ast, %{modules: [], symbols: []}, &prewalk/2, &postwalk(&1, &2, module))
+      if module == ast_module do
+        symbols = [{:attribute, "@#{name}", meta[:line], meta[:column]} | acc.symbols]
+        {ast, %{acc | symbols: symbols}}
+      else
+        {ast, acc}
+      end
+    end
 
-    symbols
-  end
+    # remove module name from modules stack on exit
+    defp postwalk({:defmodule, _, [{:__aliases__, _, _modules} | _]} = ast, acc, _module) do
+      [_exit_mudule | modules] = acc.modules
+      {ast, %{acc | modules: modules}}
+    end
 
-  # add module name to modules stack on enter
-  defp prewalk({:defmodule, _, [{:__aliases__, _, module_name_atoms} | _]} = ast, acc) do
-    modules = [module_name_atoms | acc.modules]
-    {ast, %{acc | modules: modules}}
-  end
+    defp postwalk(ast, acc, _module), do: {ast, acc}
 
-  defp prewalk(ast, acc), do: {ast, acc}
-
-  defp postwalk({:@, meta, [{name, _, args}]} = ast, acc, module) when is_list(args) do
-    ast_module =
-      acc.modules
-      |> Enum.reverse()
-      |> List.flatten()
-      |> Module.concat()
-
-    if module == ast_module do
-      symbols = [{:attribute, "@#{name}", meta[:line], meta[:column]} | acc.symbols]
-      {ast, %{acc | symbols: symbols}}
-    else
-      {ast, acc}
+    defp ast_from_file(file) do
+      file |> File.read!() |> Code.string_to_quoted!(columns: true)
     end
   end
 
-  # remove module name from modules stack on exit
-  defp postwalk({:defmodule, _, [{:__aliases__, _, _modules} | _]} = ast, acc, _module) do
-    [_exit_mudule | modules] = acc.modules
-    {ast, %{acc | modules: modules}}
-  end
+  defmodule Aliases do
+    @moduledoc """
+    Responsible for extracting the relevant portion from a single or multi alias.
 
-  defp postwalk(ast, acc, _module), do: {ast, acc}
+    ## Example
 
-  defp ast_from_file(file) do
-    file |> File.read!() |> Code.string_to_quoted!(columns: true)
+    ```elixir
+    alias Foo.Bar.Baz
+    #     ^^^^^^^^^^^
+
+    alias Foo.Bar.{Baz, Bing}
+    #              ^^^  ^^^^
+
+    alias Foo.Bar.{
+      Baz,
+    # ^^^
+      Bing
+    # ^^^^
+    }
+    ```
+    """
+
+    def extract_alias_range(code, {start, stop}, ale) do
+      lines =
+        code
+        |> String.split("\n")
+        |> Enum.map(&String.split(&1, ""))
+        |> Enum.slice((start.line - 1)..(stop.line - 1))
+
+      code =
+        if start.line == stop.line do
+          [line] = lines
+
+          line
+          |> Enum.slice(start.col..stop.col)
+          |> Enum.join()
+        else
+          [first | rest] = lines
+          first = Enum.drop(first, start.col)
+
+          [last | rest] = Enum.reverse(rest)
+
+          length = Enum.count(last)
+          last = Enum.drop(last, -(length - stop.col - 1))
+
+          Enum.map_join([first | Enum.reverse([last | rest])], "\n", &Enum.join(&1, ""))
+        end
+
+      {_, range} =
+        code
+        |> Code.string_to_quoted!(columns: true, column: start.col, token_metadata: true)
+        |> Macro.prewalk(nil, fn ast, range ->
+          range =
+            case ast do
+              {:__aliases__, meta, aliases} ->
+                if ale == List.last(aliases) do
+                  {{meta[:line] + start.line - 1, meta[:column]},
+                   {meta[:last][:line] + start.line - 1, meta[:last][:column] + String.length(to_string(ale)) - 1}}
+                else
+                  range
+                end
+
+              _ ->
+                range
+            end
+
+          {ast, range}
+        end)
+
+      range
+    end
   end
 end

--- a/lib/next_ls/db.ex
+++ b/lib/next_ls/db.ex
@@ -137,8 +137,11 @@ defmodule NextLS.DB do
     line = meta[:line] || 1
     col = meta[:column] || 0
 
-    {start_line, start_column} = {line, col}
-    {end_line, end_column} = {line, col + String.length(identifier |> to_string() |> String.replace("Elixir.", ""))}
+    {start_line, start_column} = reference[:range][:start] || {line, col}
+
+    {end_line, end_column} =
+      reference[:range][:stop] ||
+        {line, col + String.length(identifier |> to_string() |> String.replace("Elixir.", ""))}
 
     __query__(
       {conn, s.logger},

--- a/lib/next_ls/runtime/sidecar.ex
+++ b/lib/next_ls/runtime/sidecar.ex
@@ -2,7 +2,8 @@ defmodule NextLS.Runtime.Sidecar do
   @moduledoc false
   use GenServer
 
-  alias NextLS.ASTHelpers
+  alias NextLS.ASTHelpers.Aliases
+  alias NextLS.ASTHelpers.Attributes
   alias NextLS.DB
 
   def start_link(args) do
@@ -16,15 +17,38 @@ defmodule NextLS.Runtime.Sidecar do
   end
 
   def handle_info({:tracer, payload}, state) do
-    attributes = ASTHelpers.get_module_attributes(payload.file, payload.module)
+    attributes = Attributes.get_module_attributes(payload.file, payload.module)
     payload = Map.put_new(payload, :symbols, attributes)
     DB.insert_symbol(state.db, payload)
 
     {:noreply, state}
   end
 
+  def handle_info({{:tracer, :reference, :alias}, payload}, state) do
+    if payload.meta[:end_of_expression] do
+      start = %{line: payload.meta[:line], col: payload.meta[:column]}
+      stop = %{line: payload.meta[:end_of_expression][:line], col: payload.meta[:end_of_expression][:column]}
+
+      {start, stop} =
+        Aliases.extract_alias_range(
+          File.read!(payload.file),
+          {start, stop},
+          payload.identifier |> Macro.to_string() |> String.to_atom()
+        )
+
+      payload =
+        payload
+        |> Map.put(:identifier, payload.module)
+        |> Map.put(:range, %{start: start, stop: stop})
+
+      DB.insert_reference(state.db, payload)
+    end
+
+    {:noreply, state}
+  end
+
   def handle_info({{:tracer, :reference, :attribute}, payload}, state) do
-    name = ASTHelpers.get_attribute_reference_name(payload.file, payload.meta[:line], payload.meta[:column])
+    name = Attributes.get_attribute_reference_name(payload.file, payload.meta[:line], payload.meta[:column])
     if name, do: DB.insert_reference(state.db, %{payload | identifier: name})
 
     {:noreply, state}
@@ -38,7 +62,11 @@ defmodule NextLS.Runtime.Sidecar do
 
   def handle_info({{:tracer, :start}, filename}, state) do
     DB.clean_references(state.db, filename)
+    {:noreply, state}
+  end
 
+  def handle_info({{:tracer, :dbg}, payload}, state) do
+    dbg(payload)
     {:noreply, state}
   end
 end

--- a/test/next_ls/ast_helpers_test.exs
+++ b/test/next_ls/ast_helpers_test.exs
@@ -1,0 +1,52 @@
+defmodule NextLS.ASTHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias NextLS.ASTHelpers.Aliases
+
+  describe "extract_aliases" do
+    test "extracts a normal alias" do
+      code = """
+      defmodule Foo do
+        alias One.Two.Three
+      end
+      """
+
+      start = %{line: 2, col: 3}
+      stop = %{line: 2, col: 21}
+      ale = :Three
+
+      assert {{2, 9}, {2, 21}} == Aliases.extract_alias_range(code, {start, stop}, ale)
+    end
+
+    test "extract an inline multi alias" do
+      code = """
+      defmodule Foo do
+        alias One.Two.{Three, Four}
+      end
+      """
+
+      start = %{line: 2, col: 3}
+      stop = %{line: 2, col: 29}
+
+      assert {{2, 18}, {2, 22}} == Aliases.extract_alias_range(code, {start, stop}, :Three)
+      assert {{2, 25}, {2, 28}} == Aliases.extract_alias_range(code, {start, stop}, :Four)
+    end
+
+    test "extract a multi line, multi alias" do
+      code = """
+      defmodule Foo do
+        alias One.Two.{
+          Three,
+          Four
+        }
+      end
+      """
+
+      start = %{line: 2, col: 3}
+      stop = %{line: 5, col: 3}
+
+      assert {{3, 5}, {3, 9}} == Aliases.extract_alias_range(code, {start, stop}, :Three)
+      assert {{4, 5}, {4, 8}} == Aliases.extract_alias_range(code, {start, stop}, :Four)
+    end
+  end
+end

--- a/test/next_ls/references_test.exs
+++ b/test/next_ls/references_test.exs
@@ -111,6 +111,13 @@ defmodule NextLS.ReferencesTest do
                     %{
                       "uri" => ^uri,
                       "range" => %{
+                        "start" => %{"line" => 1, "character" => 8},
+                        "end" => %{"line" => 1, "character" => 18}
+                      }
+                    },
+                    %{
+                      "uri" => ^uri,
+                      "range" => %{
                         "start" => %{"line" => 3, "character" => 4},
                         "end" => %{"line" => 3, "character" => 9}
                       }


### PR DESCRIPTION
Collects references to modules in alias calls, which allows you do use go to definition and find references on them

## Example

```elixir
alias Foo.Bar.Baz
#     ^^^^^^^^^^^

alias Foo.Bar.{Baz, Bing}
#              ^^^  ^^^^

alias Foo.Bar.{
  Baz,
# ^^^
  Bing
# ^^^^
}
```
