### PR TITLE
Add dev instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,23 +75,20 @@ already).
 
 Then you can configure your editor to connect to NextLS using that port.
 
-<details>
-<summary>
-
 [elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim)
 
-</summary>
+```lua
+{
+  nextls = {enable = true, port = 9000}
+}
 
-    nextls = {enable = true, port = 9000}
+Visual Studio Code
 
-</details>
-
-<details><summary>Visual Studio Code</summary>
-
+```json
+{
     "elixir-tools.nextls.adapter": "tcp",
     "elixir-tools.nextls.port": 9000,
-
-</details>
+}
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ already).
 
 Then you can configure your editor to connect to NextLS using that port.
 
-<details><summary>If you use NeoVim</summary>
+<details>
+<summary>
+
+[elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim)
+
+</summary>
 
     nextls = {enable = true, port = 9000}
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then you can configure your editor to connect to NextLS using that port.
 
 </details>
 
-<details><summary>If you use VSCode</summary>
+<details><summary>Visual Studio Code</summary>
 
     "elixir-tools.nextls.adapter": "tcp",
     "elixir-tools.nextls.port": 9000,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ The preferred way to use Next LS is through one of the supported editor extensio
 
 If you need to install Next LS on it's own, you can download the executable hosted by the GitHub release. The executable is an Elixir script that utilizes `Mix.install/2`.
 
+## Development
+
+If you are making changes to NextLS and want to test them locally you can run
+`bin/start --port 9000` to start the language server (port 9000 is just an
+example, you can use any port that you want as long as it is not being used
+already).
+
+Then you can configure your editor to connect to NextLS using that port.
+
+<details><summary>If you use NeoVim</summary>
+
+    nextls = {enable = true, port = 9000}
+
+</details>
+
+<details><summary>If you use VSCode</summary>
+
+    "elixir-tools.nextls.adapter": "tcp",
+    "elixir-tools.nextls.port": 9000,
+
+</details>
+
 ### Note
 
 Next LS creates an `.elixir-tools` hidden directory in your project, but it will be automatically ignored by `git`.


### PR DESCRIPTION
This pull request adds a brief explanation to the README about how to start the NextLS server locally and connect your editor to it.

I added the VSCode configuration since that's what I use and the NeoVim configuration since @mhanberg posted it on Discord 😅 