### PR TITLE
fix: improve error handling for compiler diagnostics

### DIFF
--- a/lib/next_ls/extensions/elixir_extension.ex
+++ b/lib/next_ls/extensions/elixir_extension.ex
@@ -24,7 +24,7 @@ defmodule NextLS.ElixirExtension do
   end
 
   @impl GenServer
-  def handle_info({:compiler, diagnostics}, state) do
+  def handle_info({:compiler, diagnostics}, state) when is_list(diagnostics) do
     DiagnosticCache.clear(state.cache, :elixir)
 
     for d <- diagnostics do

--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -255,10 +255,6 @@ defmodule NextLS.Runtime do
   end
 
   def handle_info({:nodedown, node}, %{node: node} = state) do
-    unless is_ready(state) do
-      state.on_initialized.({:error, :nodedown})
-    end
-
     {:stop, {:shutdown, :nodedown}, state}
   end
 

--- a/test/next_ls/runtime_test.exs
+++ b/test/next_ls/runtime_test.exs
@@ -42,136 +42,168 @@ defmodule NextLs.RuntimeTest do
     [logger: logger, cwd: Path.absname(tmp_dir), on_init: on_init]
   end
 
-  test "returns the response in an ok tuple", %{logger: logger, cwd: cwd, on_init: on_init} do
-    start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
-    tvisor = start_supervised!(Task.Supervisor)
+  describe "call/2" do
+    test "responds with an ok tuple", %{logger: logger, cwd: cwd, on_init: on_init} do
+      start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
+      tvisor = start_supervised!(Task.Supervisor)
 
-    pid =
-      start_supervised!(
-        {Runtime,
-         name: "my_proj",
-         on_initialized: on_init,
-         task_supervisor: tvisor,
-         working_dir: cwd,
-         uri: "file://#{cwd}",
-         parent: self(),
-         logger: logger,
-         db: :some_db,
-         registry: RuntimeTest.Registry}
-      )
+      pid =
+        start_supervised!(
+          {Runtime,
+           name: "my_proj",
+           on_initialized: on_init,
+           task_supervisor: tvisor,
+           working_dir: cwd,
+           uri: "file://#{cwd}",
+           parent: self(),
+           logger: logger,
+           db: :some_db,
+           registry: RuntimeTest.Registry}
+        )
 
-    Process.link(pid)
+      Process.link(pid)
 
-    assert_receive :ready
+      assert_receive :ready
 
-    assert {:ok, "\"hi\""} = Runtime.call(pid, {Kernel, :inspect, ["hi"]})
-  end
-
-  test "call returns an error when the runtime is not ready", %{logger: logger, cwd: cwd, on_init: on_init} do
-    start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
-
-    tvisor = start_supervised!(Task.Supervisor)
-
-    pid =
-      start_supervised!(
-        {Runtime,
-         task_supervisor: tvisor,
-         name: "my_proj",
-         on_initialized: on_init,
-         working_dir: cwd,
-         uri: "file://#{cwd}",
-         parent: self(),
-         logger: logger,
-         db: :some_db,
-         registry: RuntimeTest.Registry}
-      )
-
-    Process.link(pid)
-
-    assert {:error, :not_ready} = Runtime.call(pid, {IO, :puts, ["hi"]})
-  end
-
-  test "compiles the code and returns diagnostics", %{logger: logger, cwd: cwd, on_init: on_init} do
-    start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
-
-    tvisor = start_supervised!(Task.Supervisor)
-
-    pid =
-      start_link_supervised!(
-        {Runtime,
-         name: "my_proj",
-         on_initialized: on_init,
-         task_supervisor: tvisor,
-         working_dir: cwd,
-         uri: "file://#{cwd}",
-         parent: self(),
-         logger: logger,
-         db: :some_db,
-         registry: RuntimeTest.Registry}
-      )
-
-    assert_receive :ready
-
-    file = Path.join(cwd, "lib/bar.ex")
-
-    assert [
-             %Mix.Task.Compiler.Diagnostic{
-               file: ^file,
-               severity: :warning,
-               message:
-                 "variable \"arg1\" is unused (if the variable is not meant to be used, prefix it with an underscore)",
-               position: position,
-               compiler_name: "Elixir",
-               details: nil
-             }
-           ] = Runtime.compile(pid)
-
-    if Version.match?(System.version(), ">= 1.15.0") do
-      assert position == {4, 11}
-    else
-      assert position == 4
+      assert {:ok, "\"hi\""} = Runtime.call(pid, {Kernel, :inspect, ["hi"]})
     end
 
-    File.write!(file, """
-    defmodule Bar do
-      def foo(arg1) do
-        arg1
+    test "responds with an error when the runtime isn't ready",
+         %{logger: logger, cwd: cwd, on_init: on_init} do
+      start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
+
+      tvisor = start_supervised!(Task.Supervisor)
+
+      pid =
+        start_supervised!(
+          {Runtime,
+           task_supervisor: tvisor,
+           name: "my_proj",
+           on_initialized: on_init,
+           working_dir: cwd,
+           uri: "file://#{cwd}",
+           parent: self(),
+           logger: logger,
+           db: :some_db,
+           registry: RuntimeTest.Registry}
+        )
+
+      Process.link(pid)
+
+      assert {:error, :not_ready} = Runtime.call(pid, {IO, :puts, ["hi"]})
+    end
+  end
+
+  describe "compile/1" do
+    test "compiles the project and returns diagnostics",
+         %{logger: logger, cwd: cwd, on_init: on_init} do
+      start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
+
+      tvisor = start_supervised!(Task.Supervisor)
+
+      pid =
+        start_link_supervised!(
+          {Runtime,
+           name: "my_proj",
+           on_initialized: on_init,
+           task_supervisor: tvisor,
+           working_dir: cwd,
+           uri: "file://#{cwd}",
+           parent: self(),
+           logger: logger,
+           db: :some_db,
+           registry: RuntimeTest.Registry}
+        )
+
+      assert_receive :ready
+
+      file = Path.join(cwd, "lib/bar.ex")
+
+      assert [
+               %Mix.Task.Compiler.Diagnostic{
+                 file: ^file,
+                 severity: :warning,
+                 message:
+                   "variable \"arg1\" is unused (if the variable is not meant to be used, prefix it with an underscore)",
+                 position: position,
+                 compiler_name: "Elixir",
+                 details: nil
+               }
+             ] = Runtime.compile(pid)
+
+      if Version.match?(System.version(), ">= 1.15.0") do
+        assert position == {4, 11}
+      else
+        assert position == 4
       end
+
+      File.write!(file, """
+      defmodule Bar do
+        def foo(arg1) do
+          arg1
+        end
+      end
+      """)
+
+      assert [] == Runtime.compile(pid)
     end
-    """)
 
-    assert [] == Runtime.compile(pid)
-  end
+    test "emits errors when runtime compilation fails",
+         %{tmp_dir: tmp_dir, logger: logger, cwd: cwd, on_init: on_init} do
+      # obvious syntax error
+      bad_mix_exs = String.replace(mix_exs(), "defmodule", "")
+      File.write!(Path.join(tmp_dir, "mix.exs"), bad_mix_exs)
 
-  test "emits errors when runtime compilation fails", %{tmp_dir: tmp_dir, logger: logger, cwd: cwd, on_init: on_init} do
-    # obvious syntax error
-    bad_mix_exs = String.replace(mix_exs(), "defmodule", "")
-    File.write!(Path.join(tmp_dir, "mix.exs"), bad_mix_exs)
+      start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
 
-    start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
+      tvisor = start_supervised!(Task.Supervisor)
 
-    tvisor = start_supervised!(Task.Supervisor)
+      start_supervised!(
+        {Runtime,
+         task_supervisor: tvisor,
+         name: "my_proj",
+         on_initialized: on_init,
+         working_dir: cwd,
+         uri: "file://#{cwd}",
+         parent: self(),
+         logger: logger,
+         db: :some_db,
+         registry: RuntimeTest.Registry},
+        restart: :temporary
+      )
 
-    start_supervised!(
-      {Runtime,
-       task_supervisor: tvisor,
-       name: "my_proj",
-       on_initialized: on_init,
-       working_dir: cwd,
-       uri: "file://#{cwd}",
-       parent: self(),
-       logger: logger,
-       db: :some_db,
-       registry: RuntimeTest.Registry},
-      restart: :temporary
-    )
+      assert_receive {:error, {:port_down, :normal}}
 
-    assert_receive {:error, {:port_down, :normal}}
+      assert_receive {:log, :log, log_msg}
+      assert log_msg =~ "syntax error"
 
-    assert_receive {:log, :log, log_msg}
-    assert log_msg =~ "syntax error"
+      assert_receive {:log, :error, error_msg}
+      assert error_msg =~ "{:shutdown, {:port_down, :normal}}"
+    end
 
-    assert_receive {:log, :error, error_msg}
-    assert error_msg =~ "{:shutdown, {:port_down, :normal}}"
+    test "responds with an error when the runtime isn't ready",
+         %{logger: logger, cwd: cwd, on_init: on_init} do
+      start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
+
+      tvisor = start_supervised!(Task.Supervisor)
+
+      pid =
+        start_supervised!(
+          {Runtime,
+           task_supervisor: tvisor,
+           name: "my_proj",
+           on_initialized: on_init,
+           working_dir: cwd,
+           uri: "file://#{cwd}",
+           parent: self(),
+           logger: logger,
+           db: :some_db,
+           registry: RuntimeTest.Registry}
+        )
+
+      Process.link(pid)
+
+      assert {:error, :not_ready} = Runtime.compile(pid)
+    end
   end
 end

--- a/test/next_ls/runtime_test.exs
+++ b/test/next_ls/runtime_test.exs
@@ -39,6 +39,8 @@ defmodule NextLs.RuntimeTest do
 
     on_init = fn msg -> send(me, msg) end
 
+    on_exit(&flush_messages/0)
+
     [logger: logger, cwd: Path.absname(tmp_dir), on_init: on_init]
   end
 
@@ -236,6 +238,14 @@ defmodule NextLs.RuntimeTest do
       Process.link(pid)
 
       assert {:error, :not_ready} = Runtime.compile(pid)
+    end
+  end
+
+  defp flush_messages do
+    receive do
+      _ -> flush_messages()
+    after
+      0 -> :ok
     end
   end
 end

--- a/test/next_ls/runtime_test.exs
+++ b/test/next_ls/runtime_test.exs
@@ -135,8 +135,7 @@ defmodule NextLs.RuntimeTest do
       assert {:ok, "\"hi\""} = Runtime.call(pid, {Kernel, :inspect, ["hi"]})
     end
 
-    test "responds with an error when the runtime hasn't initialized",
-         %{logger: logger, cwd: cwd, on_init: on_init} do
+    test "responds with an error when the runtime hasn't initialized", %{logger: logger, cwd: cwd, on_init: on_init} do
       start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
 
       tvisor = start_supervised!(Task.Supervisor)
@@ -215,8 +214,7 @@ defmodule NextLs.RuntimeTest do
       assert [] == Runtime.compile(pid)
     end
 
-    test "responds with an error when the runtime isn't ready",
-         %{logger: logger, cwd: cwd, on_init: on_init} do
+    test "responds with an error when the runtime isn't ready", %{logger: logger, cwd: cwd, on_init: on_init} do
       start_supervised!({Registry, keys: :duplicate, name: RuntimeTest.Registry})
 
       tvisor = start_supervised!(Task.Supervisor)

--- a/test/next_ls/runtime_test.exs
+++ b/test/next_ls/runtime_test.exs
@@ -67,13 +67,13 @@ defmodule NextLs.RuntimeTest do
         restart: :temporary
       )
 
-      assert_receive {:error, {:port_down, :normal}}
+      assert_receive {:error, :portdown}
 
       assert_receive {:log, :log, log_msg}
       assert log_msg =~ "syntax error"
 
       assert_receive {:log, :error, error_msg}
-      assert error_msg =~ "{:shutdown, {:port_down, :normal}}"
+      assert error_msg =~ "{:shutdown, :portdown}"
     end
 
     test "emitted on crash after initialization",
@@ -101,10 +101,8 @@ defmodule NextLs.RuntimeTest do
 
       assert {:ok, {:badrpc, :nodedown}} = Runtime.call(pid, {System, :halt, [1]})
 
-      assert_receive {:log, :warning, warning_msg}
-      assert warning_msg =~ ~r"Connected node [^ ]+ is down. Exiting my_proj runtime."
-
-      assert_receive {:log, :log, "The runtime for my_proj has successfully shut down."}
+      assert_receive {:log, :error, error_msg}
+      assert error_msg =~ "{:shutdown, :nodedown}"
     end
   end
 

--- a/test/next_ls/workspaces_test.exs
+++ b/test/next_ls/workspaces_test.exs
@@ -89,7 +89,7 @@ defmodule NextLS.WorkspacesTest do
       }
     })
 
-    message = "[NextLS] The runtime for #{context.module}-proj_two has successfully shutdown."
+    message = "[NextLS] The runtime for #{context.module}-proj_two has successfully shut down."
 
     assert_notification "window/logMessage", %{
       "message" => ^message

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -83,11 +83,15 @@ defmodule NextLS.Support.Utils do
     [server: server, client: client]
   end
 
-  defmacro assert_is_ready(context, name) do
+  defmacro assert_is_ready(
+             context,
+             name,
+             timeout \\ Application.get_env(:ex_unit, :assert_receive_timeout)
+           ) do
     quote do
       message = "[NextLS] Runtime for folder #{unquote(context).module}-#{unquote(name)} is ready..."
 
-      assert_notification "window/logMessage", %{"message" => ^message}
+      assert_notification "window/logMessage", %{"message" => ^message}, unquote(timeout)
     end
   end
 


### PR DESCRIPTION
Playing around with Next LS this morning and was running up against some issues compiling a project of mine. I think the previous handling of `:badrpc` errors was incorrect, which was hiding certain errors of causing them to bubble up in weird ways (like trying iterate over an atom).