### PR TITLE
ci: add build cache to dialyzer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,10 +90,12 @@ jobs:
         id: plt_cache
         with:
           key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
           path: |
+            deps
+            _build
             priv/plts
 
       - name: Install Dependencies
@@ -112,8 +114,10 @@ jobs:
         id: plt_cache_save
         with:
           key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock') }}
           path: |
+            deps
+            _build
             priv/plts
 
       - name: Run dialyzer


### PR DESCRIPTION
I noticed `mix dialyzer` takes >= 1 minute, of which only 4 seconds is dialyzer. This PR should ensure that the built dependencies are also cached.