### PR TITLE
Don't clean references on every file save

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -454,21 +454,12 @@ defmodule NextLS do
 
     refresh_refs =
       dispatch(lsp.assigns.registry, :runtimes, fn entries ->
-        for {pid, %{name: name, uri: wuri, db: db}} <- entries, String.starts_with?(uri, wuri), into: %{} do
+        for {pid, %{name: name, uri: wuri}} <- entries, String.starts_with?(uri, wuri), into: %{} do
           token = Progress.token()
           Progress.start(lsp, token, "Compiling #{name}...")
 
           task =
             Task.Supervisor.async_nolink(lsp.assigns.task_supervisor, fn ->
-              DB.query(
-                db,
-                ~Q"""
-                DELETE FROM 'references'
-                WHERE file = ?;
-                """,
-                [URI.parse(uri).path]
-              )
-
               {name, Runtime.compile(pid)}
             end)
 

--- a/lib/next_ls/db.ex
+++ b/lib/next_ls/db.ex
@@ -144,8 +144,6 @@ defmodule NextLS.DB do
     {:message_queue_len, count} = Process.info(self(), :message_queue_len)
     NextLS.DB.Activity.update(s.activity, count)
 
-    NextLS.Logger.warning(s.logger, "CLEANING REFERENCES FOR #{filename}")
-
     __query__(
       {conn, s.logger},
       ~Q"""

--- a/lib/next_ls/db.ex
+++ b/lib/next_ls/db.ex
@@ -19,7 +19,7 @@ defmodule NextLS.DB do
   @spec insert_reference(pid(), map()) :: :ok
   def insert_reference(server, payload), do: GenServer.cast(server, {:insert_reference, payload})
 
-  @spec insert_reference(pid(), String.t()) :: :ok
+  @spec clean_references(pid(), String.t()) :: :ok
   def clean_references(server, filename), do: GenServer.cast(server, {:clean_references, filename})
 
   def init(args) do

--- a/lib/next_ls/runtime/sidecar.ex
+++ b/lib/next_ls/runtime/sidecar.ex
@@ -25,4 +25,10 @@ defmodule NextLS.Runtime.Sidecar do
 
     {:noreply, state}
   end
+
+  def handle_info({{:tracer, :start}, filename}, state) do
+    DB.clean_references(state.db, filename)
+
+    {:noreply, state}
+  end
 end

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -55,7 +55,7 @@ defmodule NextLSPrivate.Tracer do
   def trace(:start, env) do
     Process.send(
       parent_pid(),
-      {{:tracer, :start}, URI.parse(env.file).path},
+      {{:tracer, :start}, env.file},
       []
     )
 

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -52,7 +52,13 @@ defmodule NextLSPrivate.Tracer do
 
   @source "user"
 
-  def trace(:start, _env) do
+  def trace(:start, env) do
+    Process.send(
+      parent_pid(),
+      {{:tracer, :start}, URI.parse(env.file).path},
+      []
+    )
+
     :ok
   end
 


### PR DESCRIPTION
This pull request stops cleaning file references on every file save and, instead, cleans them only when we compile the file.

On the one hand we stop cleaning the file references on the `TextDocumentDidSave` notification. On the other hand we now clean the references on the `:start` event of the compiler tracer.

As per [the Elixir docs](https://hexdocs.pm/elixir/Code.html#module-compilation-tracers):

> `:start` - (since v1.11.0) invoked whenever the compiler starts to trace a new lexical context. A lexical context is started when compiling a new file or when defining a module within a function

Since this is only executed when compiling a file or defining a module we know that it is safe to to clean references at this point, since new ones will be populated during the compilation that just started.

The following video shows an example. Observe how the terminal at the bottom of the screen says "CLEANING REFERENCES FOR $FILE" when I update the file contents but doesn't do anything when I save without changing the file contents.

https://github.com/elixir-tools/next-ls/assets/2965623/476bf62a-5114-4a7b-8772-23fbeea65c88




Closes #154 