### PR TITLE
ci: don't cache _build and deps for dialyzer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,8 +94,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
           path: |
-            deps
-            _build
             priv/plts
 
       - name: Install Dependencies
@@ -116,8 +114,6 @@ jobs:
           key: |
             ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock') }}
           path: |
-            deps
-            _build
             priv/plts
 
       - name: Run dialyzer


### PR DESCRIPTION
ci: don't cache _build and deps for dialyzer

this is causing some weird problem where it can't find dialyzer, the
added CI time is worth passing builds for now
