### PR TITLE
fix: redirect logger to stderr

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,6 @@ import Config
 
 config :next_ls, :indexing_timeout, 100
 
+config :logger, :default_handler, config: [type: :standard_error]
+
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
This makes error logs show up in VSCode's error window without
interfering with communication over stdout.
