### PR TITLE
fix: use otp26-compiled version of Elixir

### DIFF
--- a/.rtx.toml
+++ b/.rtx.toml
@@ -1,4 +1,4 @@
 [tools]
-elixir = "1.15.4"
 erlang = "26.0.2"
+elixir = "1.15.4-otp-26"
 zig = "0.10.0"


### PR DESCRIPTION
This also reorders Erlang and Elixir so that rtx installs Erlang first.
This is helpful for anyone using a .default-mix-commands to
automatically install archives when rtx installs Elixir.
