### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Visual Studio Code
 
 ```json
 {
-  "elixir-tools.nextls.adapter": "tcp",
-  "elixir-tools.nextls.port": 9000
+  "elixir-tools.nextLS.adapter": "tcp",
+  "elixir-tools.nextLS.port": 9000
 }
 ```
 


### PR DESCRIPTION
Hi NextLS folks,

I'm working on integrating NextLS into [Zed](https://zed.dev/), and along the way I tripped over a tiny typo in the NextLS README. Thought I'd fix the problem while I'm at it. 

Hope y'all have a great week :)