### PR TITLE
Fix installation commands copying in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ The extension will automatically install the latest version of Next LS and will 
 ### Homebrew
 
 ```bash
-$ brew install elixir-tools/tap/next-ls
+brew install elixir-tools/tap/next-ls
 ```
 
 ### Nix
 
 ```bash
-$ nix profile install github:elixir-tools/next-ls
+nix profile install github:elixir-tools/next-ls
 ```
 
 ### GitHub Releases


### PR DESCRIPTION
The `$` in front of the command was causing `command not found: $` error when using the copy button next to the snippet in the README.md file.