### PR TITLE
Ignore unknown reference types

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -359,6 +359,9 @@ defmodule NextLS do
                     _ ->
                       nil
                   end
+
+                nil ->
+                  nil
               end
             else
               _ -> nil


### PR DESCRIPTION
This fixes the following exception that I started getting with VSCode
1.82.3:

```
** (CaseClauseError) no case clause matching: "attribute"
    (next_ls 0.13.4) lib/next_ls.ex:337: NextLS.handle_request/2
    (gen_lsp 0.6.0) lib/gen_lsp.ex:248: anonymous fn/5 in GenLSP.loop/3
    (gen_lsp 0.6.0) lib/gen_lsp.ex:308: GenLSP.attempt/3
    (stdlib 5.0.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```

Fixes #280.
