### PR TITLE
feat: completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Still in heavy development, currently supporting the following features:
 - Extensions
   - Credo
 - Hover
+- Completions †
+
+† - denotes an experimental feature, which can be toggled on/off
 
 ## Supported Elixir Versions
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Still in heavy development, currently supporting the following features:
 - Extensions
   - Credo
 - Hover
-- Completions †
+- Completions †‡
 
-† - denotes an experimental feature, which can be toggled on/off
+† - denotes an experimental feature, which can be toggled on/off.
+‡ - denotes a partially implemented feature.
 
 ## Supported Elixir Versions
 

--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -121,7 +121,7 @@ defmodule NextLS do
          completion_provider:
            if init_opts.experimental.completions.enabled do
              %GenLSP.Structures.CompletionOptions{
-               trigger_characters: [".", "@", "&", "%", "^", ":", "!", "-", "~", "/"]
+               trigger_characters: [".", "@", "&", "%", "^", ":", "!", "-", "~", "/", "{"]
              }
            else
              nil
@@ -536,7 +536,7 @@ defmodule NextLS do
           end
 
         case result do
-          {:yes, _, entries} -> entries
+          {:yes, entries} -> entries
           _ -> []
         end
       end)

--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -119,7 +119,7 @@ defmodule NextLS do
            change: TextDocumentSyncKind.full()
          },
          completion_provider:
-           if init_opts.experimental.completions.enabled do
+           if init_opts.experimental.completions.enable do
              %GenLSP.Structures.CompletionOptions{
                trigger_characters: [".", "@", "&", "%", "^", ":", "!", "-", "~", "/", "{"]
              }
@@ -1084,7 +1084,7 @@ defmodule NextLS do
 
   defmodule InitOpts.Experimental do
     @moduledoc false
-    defstruct completions: %{enabled: false}
+    defstruct completions: %{enable: false}
   end
 
   defmodule InitOpts do
@@ -1103,7 +1103,7 @@ defmodule NextLS do
               schema(NextLS.InitOpts.Experimental, %{
                 optional(:completions) =>
                   map(%{
-                    {"enabled", :enabled} => bool()
+                    {"enable", :enable} => bool()
                   })
               })
           })

--- a/lib/next_ls/autocomplete.ex
+++ b/lib/next_ls/autocomplete.ex
@@ -772,12 +772,13 @@ defmodule NextLS.Autocomplete do
     []
   end
 
-  defp variables_from_binding(hint, _runtime) do
-    {:ok, ast} = Code.Fragment.container_cursor_to_quoted(hint, columns: true)
+  defp variables_from_binding(_hint, _runtime) do
+    # {:ok, ast} = Code.Fragment.container_cursor_to_quoted(hint, columns: true)
 
     # ast |> Macro.to_string() |> IO.puts()
 
-    NextLS.ASTHelpers.Variables.collect(ast)
+    # NextLS.ASTHelpers.Variables.collect(ast)
+    []
   end
 
   defp value_from_binding([_var | _path], _runtime) do

--- a/lib/next_ls/autocomplete.ex
+++ b/lib/next_ls/autocomplete.ex
@@ -1,0 +1,879 @@
+defmodule NextLS.Autocomplete do
+  @moduledoc false
+
+  require NextLS.Runtime
+
+  @bitstring_modifiers [
+    %{kind: :variable, name: "big"},
+    %{kind: :variable, name: "binary"},
+    %{kind: :variable, name: "bitstring"},
+    %{kind: :variable, name: "integer"},
+    %{kind: :variable, name: "float"},
+    %{kind: :variable, name: "little"},
+    %{kind: :variable, name: "native"},
+    %{kind: :variable, name: "signed"},
+    %{kind: :function, name: "size", arity: 1},
+    %{kind: :function, name: "unit", arity: 1},
+    %{kind: :variable, name: "unsigned"},
+    %{kind: :variable, name: "utf8"},
+    %{kind: :variable, name: "utf16"},
+    %{kind: :variable, name: "utf32"}
+  ]
+
+  @alias_only_atoms ~w(alias import require)a
+  @alias_only_charlists ~w(alias import require)c
+
+  @doc """
+  The expansion logic.
+
+  Some of the expansion has to be use the current shell
+  environment, which is found via the broker.
+  """
+  def expand(code, shell) do
+    case path_fragment(code) do
+      [] -> expand_code(code, shell)
+      path -> expand_path(path)
+    end
+  end
+
+  defp expand_code(code, shell) do
+    code = Enum.reverse(code)
+    helper = get_helper(code)
+
+    case Code.Fragment.cursor_context(code) do
+      {:alias, alias} ->
+        expand_aliases(List.to_string(alias), shell)
+
+      {:unquoted_atom, unquoted_atom} ->
+        expand_erlang_modules(List.to_string(unquoted_atom), shell)
+
+      expansion when helper == ?b ->
+        expand_typespecs(expansion, shell, &get_module_callbacks(&1, shell))
+
+      expansion when helper == ?t ->
+        expand_typespecs(expansion, shell, &get_module_types(&1, shell))
+
+      {:dot, path, hint} ->
+        if alias = alias_only(path, hint, code, shell) do
+          dbg(alias)
+          expand_aliases(List.to_string(alias), shell)
+        else
+          dbg(hint)
+          expand_dot(path, List.to_string(hint), false, shell)
+        end
+
+      {:dot_arity, path, hint} ->
+        expand_dot(path, List.to_string(hint), true, shell)
+
+      {:dot_call, path, hint} ->
+        path |> expand_dot_call(List.to_atom(hint), shell) |> dbg()
+
+      :expr ->
+        expand_container_context(code, :expr, "", shell) || expand_local_or_var("", "", shell)
+
+      {:local_or_var, local_or_var} ->
+        hint = List.to_string(code)
+
+        expand_container_context(code, :expr, hint, shell) ||
+          expand_local_or_var(hint, List.to_string(local_or_var), shell)
+
+      {:local_arity, local} ->
+        expand_local(List.to_string(local), true, shell)
+
+      {:local_call, local} when local in @alias_only_charlists ->
+        expand_aliases("", shell)
+
+      {:local_call, local} ->
+        expand_local_call(List.to_atom(local), shell)
+
+      {:operator, operator} when operator in ~w(:: -)c ->
+        expand_container_context(code, :operator, "", shell) ||
+          expand_local(List.to_string(operator), false, shell)
+
+      {:operator, operator} ->
+        expand_local(List.to_string(operator), false, shell)
+
+      {:operator_arity, operator} ->
+        expand_local(List.to_string(operator), true, shell)
+
+      {:operator_call, operator} when operator in ~w(|)c ->
+        expand_container_context(code, :expr, "", shell) || expand_local_or_var("", "", shell)
+
+      {:operator_call, _operator} ->
+        expand_local_or_var("", "", shell)
+
+      {:sigil, []} ->
+        expand_sigil(shell)
+
+      {:sigil, [_]} ->
+        {:yes, [], ~w|" """ ' ''' \( / < [ { \||c}
+
+      {:struct, struct} when is_list(struct) ->
+        expand_structs(List.to_string(struct), shell)
+
+      {:struct, {:dot, {:alias, struct}, ~c""}} when is_list(struct) ->
+        expand_structs(List.to_string(struct ++ ~c"."), shell)
+
+      # {:module_attribute, charlist}
+      # :none
+      _ ->
+        no()
+    end
+  end
+
+  defp get_helper(expr) do
+    with [helper | rest] when helper in ~c"bt" <- expr,
+         [space_or_paren, char | _] <- squeeze_spaces(rest),
+         true <-
+           space_or_paren in ~c" (" and
+             (char in ?A..?Z or char in ?a..?z or char in ?0..?9 or char in ~c"_:") do
+      helper
+    else
+      _ -> nil
+    end
+  end
+
+  defp squeeze_spaces(~c"  " ++ rest), do: squeeze_spaces([?\s | rest])
+  defp squeeze_spaces(rest), do: rest
+
+  @doc false
+  def exports(mod, shell) do
+    {:ok, exported?} = NextLS.Runtime.execute(shell, do: Kernel.function_exported?(mod, :__info__, 1))
+
+    if ensure_loaded?(mod, shell) and exported? do
+      mod.__info__(:macros) ++ (mod.__info__(:functions) -- [__info__: 1])
+    else
+      mod.module_info(:exports) -- [module_info: 0, module_info: 1]
+    end
+  end
+
+  ## Typespecs
+
+  defp expand_typespecs({:dot, path, hint}, shell, fun) do
+    hint = List.to_string(hint)
+
+    case expand_dot_path(path, shell) do
+      {:ok, mod} when is_atom(mod) ->
+        mod
+        |> fun.()
+        |> then(&match_module_funs(shell, mod, &1, hint, false))
+        |> format_expansion(hint)
+
+      _ ->
+        no()
+    end
+  end
+
+  defp expand_typespecs(_, _, _), do: no()
+
+  ## Expand call
+
+  defp expand_local_call(fun, shell) do
+    shell
+    |> imports_from_env()
+    |> Enum.filter(fn {_, funs} -> List.keymember?(funs, fun, 0) end)
+    |> Enum.flat_map(fn {module, _} -> get_signatures(fun, module) end)
+    |> expand_signatures(shell)
+  end
+
+  defp expand_dot_call(path, fun, shell) do
+    case expand_dot_path(path, shell) do
+      {:ok, mod} when is_atom(mod) -> fun |> get_signatures(mod) |> expand_signatures(shell)
+      _ -> no()
+    end
+  end
+
+  defp get_signatures(name, module) when is_atom(module) do
+    with docs when is_list(docs) <- get_docs(module, [:function, :macro], name) do
+      Enum.map(docs, fn {_, _, signatures, _, _} -> Enum.join(signatures, " ") end)
+    else
+      _ -> []
+    end
+  end
+
+  defp expand_signatures([_ | _] = signatures, _shell) do
+    [head | tail] = Enum.sort(signatures, &(String.length(&1) <= String.length(&2)))
+    if tail != [], do: IO.write("\n" <> (tail |> Enum.reverse() |> Enum.join("\n")))
+    yes("", [head])
+  end
+
+  defp expand_signatures([], shell), do: expand_local_or_var("", "", shell)
+
+  ## Expand dot
+
+  defp expand_dot(path, hint, exact?, shell) do
+    case expand_dot_path(path, shell) do
+      {:ok, mod} when is_atom(mod) and hint == "" -> expand_dot_aliases(mod, shell)
+      {:ok, mod} when is_atom(mod) -> expand_require(mod, hint, exact?, shell)
+      {:ok, map} when is_map(map) -> expand_map_field_access(map, hint)
+      _ -> no()
+    end
+  end
+
+  defp expand_dot_path({:unquoted_atom, var}, _shell) do
+    {:ok, List.to_atom(var)}
+  end
+
+  defp expand_dot_path(path, shell) do
+    case recur_expand_dot_path(path, shell) do
+      {:ok, [_ | _] = path} -> value_from_binding(Enum.reverse(path), shell)
+      other -> other
+    end
+  end
+
+  defp recur_expand_dot_path({:var, var}, _shell) do
+    {:ok, [List.to_atom(var)]}
+  end
+
+  defp recur_expand_dot_path({:alias, var}, shell) do
+    {:ok, var |> List.to_string() |> String.split(".") |> value_from_alias(shell)}
+  end
+
+  defp recur_expand_dot_path({:dot, parent, call}, shell) do
+    case recur_expand_dot_path(parent, shell) do
+      {:ok, [_ | _] = path} -> {:ok, [List.to_atom(call) | path]}
+      _ -> :error
+    end
+  end
+
+  defp recur_expand_dot_path(_, _shell) do
+    :error
+  end
+
+  defp expand_map_field_access(map, hint) do
+    case match_map_fields(map, hint) do
+      [%{kind: :map_key, name: ^hint, value_is_map: false}] -> no()
+      map_fields when is_list(map_fields) -> format_expansion(map_fields, hint)
+    end
+  end
+
+  defp expand_dot_aliases(mod, shell) do
+    all = match_elixir_modules(mod, "", shell) ++ match_module_funs(shell, mod, get_module_funs(mod, shell), "", false)
+    format_expansion(all, "")
+  end
+
+  defp expand_require(mod, hint, exact?, shell) do
+    mod
+    |> get_module_funs(shell)
+    |> then(&match_module_funs(shell, mod, &1, hint, exact?))
+    |> format_expansion(hint)
+  end
+
+  ## Expand local or var
+
+  defp expand_local_or_var(code, hint, shell) do
+    format_expansion(match_var(code, hint, shell) ++ match_local(code, false, shell), hint)
+  end
+
+  defp expand_local(hint, exact?, shell) do
+    format_expansion(match_local(hint, exact?, shell), hint)
+  end
+
+  defp expand_sigil(shell) do
+    sigils =
+      "sigil_"
+      |> match_local(false, shell)
+      |> Enum.map(fn %{name: "sigil_" <> rest} -> %{kind: :sigil, name: rest} end)
+
+    format_expansion(match_local("~", false, shell) ++ sigils, "~")
+  end
+
+  defp match_local(hint, exact?, shell) do
+    imports = shell |> imports_from_env() |> Enum.flat_map(&elem(&1, 1))
+    module_funs = get_module_funs(Kernel.SpecialForms, shell)
+    match_module_funs(shell, nil, imports ++ module_funs, hint, exact?)
+  end
+
+  defp match_var(code, hint, shell) do
+    code
+    |> variables_from_binding(shell)
+    |> Enum.filter(&String.starts_with?(&1, hint))
+    |> Enum.sort()
+    |> Enum.map(&%{kind: :variable, name: &1})
+  end
+
+  ## Erlang modules
+
+  defp expand_erlang_modules(hint, shell) do
+    format_expansion(match_erlang_modules(hint, shell), hint)
+  end
+
+  defp match_erlang_modules(hint, shell) do
+    for mod <- match_modules(hint, false, shell), usable_as_unquoted_module?(mod) do
+      %{kind: :module, name: mod}
+    end
+  end
+
+  ## Structs
+
+  defp expand_structs(hint, shell) do
+    aliases =
+      for {alias, mod} <- aliases_from_env(shell),
+          [name] = Module.split(alias),
+          String.starts_with?(name, hint),
+          do: {mod, name}
+
+    modules =
+      for "Elixir." <> name = full_name <- match_modules("Elixir." <> hint, true, shell),
+          String.starts_with?(name, hint),
+          mod = String.to_atom(full_name),
+          do: {mod, name}
+
+    all = aliases ++ modules
+    {:ok, _} = NextLS.Runtime.execute(shell, do: Code.ensure_all_loaded(Enum.map(all, &elem(&1, 0))))
+
+    refs =
+      for {mod, name} <- all,
+          function_exported?(mod, :__struct__, 1) and not function_exported?(mod, :exception, 1),
+          do: %{kind: :struct, name: name}
+
+    format_expansion(refs, hint)
+  end
+
+  defp expand_container_context(code, context, hint, shell) do
+    case container_context(code, shell) do
+      {:map, map, pairs} when context == :expr ->
+        container_context_map_fields(pairs, map, hint)
+
+      {:struct, alias, pairs} when context == :expr ->
+        map = Map.from_struct(alias.__struct__)
+        container_context_map_fields(pairs, map, hint)
+
+      :bitstring_modifier ->
+        existing =
+          code
+          |> List.to_string()
+          |> String.split("::")
+          |> List.last()
+          |> String.split("-")
+
+        @bitstring_modifiers
+        |> Enum.filter(&(String.starts_with?(&1.name, hint) and &1.name not in existing))
+        |> format_expansion(hint)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp container_context_map_fields(pairs, map, hint) do
+    pairs =
+      Enum.reduce(pairs, map, fn {key, _}, map ->
+        Map.delete(map, key)
+      end)
+
+    entries =
+      for {key, _value} <- pairs,
+          name = Atom.to_string(key),
+          if(hint == "",
+            do: not String.starts_with?(name, "_"),
+            else: String.starts_with?(name, hint)
+          ),
+          do: %{kind: :keyword, name: name}
+
+    format_expansion(entries, hint)
+  end
+
+  defp container_context(code, shell) do
+    case Code.Fragment.container_cursor_to_quoted(code, columns: true) do
+      {:ok, quoted} ->
+        case Macro.path(quoted, &match?({:__cursor__, _, []}, &1)) do
+          [cursor, {:%{}, _, pairs}, {:%, _, [{:__aliases__, _, aliases}, _map]} | _] ->
+            container_context_struct(cursor, pairs, aliases, shell)
+
+          [
+            cursor,
+            pairs,
+            {:|, _, _},
+            {:%{}, _, _},
+            {:%, _, [{:__aliases__, _, aliases}, _map]} | _
+          ] ->
+            container_context_struct(cursor, pairs, aliases, shell)
+
+          [cursor, pairs, {:|, _, [{variable, _, nil} | _]}, {:%{}, _, _} | _] ->
+            container_context_map(cursor, pairs, variable, shell)
+
+          [cursor, {special_form, _, [cursor]} | _] when special_form in @alias_only_atoms ->
+            :alias_only
+
+          [cursor | tail] ->
+            case remove_operators(tail, cursor) do
+              [{:"::", _, [_, _]}, {:<<>>, _, [_ | _]} | _] -> :bitstring_modifier
+              _ -> nil
+            end
+
+          _ ->
+            nil
+        end
+
+      {:error, _} ->
+        nil
+    end
+  end
+
+  defp remove_operators([{op, _, [_, previous]} = head | tail], previous) when op in [:-],
+    do: remove_operators(tail, head)
+
+  defp remove_operators(tail, _previous), do: tail
+
+  defp container_context_struct(cursor, pairs, aliases, shell) do
+    with {pairs, [^cursor]} <- Enum.split(pairs, -1),
+         alias = value_from_alias(aliases, shell),
+         true <-
+           Keyword.keyword?(pairs) and ensure_loaded?(alias, shell) and
+             function_exported?(alias, :__struct__, 1) do
+      {:struct, alias, pairs}
+    else
+      _ -> nil
+    end
+  end
+
+  defp container_context_map(cursor, pairs, variable, shell) do
+    with {pairs, [^cursor]} <- Enum.split(pairs, -1),
+         {:ok, map} when is_map(map) <- value_from_binding([variable], shell),
+         true <- Keyword.keyword?(pairs) do
+      {:map, map, pairs}
+    else
+      _ -> nil
+    end
+  end
+
+  ## Aliases and modules
+
+  defp alias_only(path, hint, code, shell) do
+    with {:alias, alias} <- path,
+         [] <- hint,
+         :alias_only <- container_context(code, shell) do
+      alias ++ [?.]
+    else
+      _ -> nil
+    end
+  end
+
+  defp expand_aliases(all, shell) do
+    case String.split(all, ".") do
+      [hint] ->
+        all = match_aliases(hint, shell) ++ match_elixir_modules(Elixir, hint, shell)
+        format_expansion(all, hint)
+
+      parts ->
+        hint = List.last(parts)
+        list = Enum.take(parts, length(parts) - 1)
+
+        list
+        |> value_from_alias(shell)
+        |> match_elixir_modules(hint, shell)
+        |> format_expansion(hint)
+    end
+  end
+
+  defp value_from_alias([name | rest], shell) do
+    case Keyword.fetch(aliases_from_env(shell), Module.concat(Elixir, name)) do
+      {:ok, name} when rest == [] -> name
+      {:ok, name} -> Module.concat([name | rest])
+      :error -> Module.concat([name | rest])
+    end
+  end
+
+  defp match_aliases(hint, shell) do
+    for {alias, module} <- aliases_from_env(shell),
+        [name] = Module.split(alias),
+        String.starts_with?(name, hint) do
+      %{kind: :module, name: name, module: module}
+    end
+  end
+
+  defp match_elixir_modules(module, hint, shell) do
+    name = Atom.to_string(module)
+    depth = length(String.split(name, ".")) + 1
+    base = name <> "." <> hint
+
+    for mod <- match_modules(base, module == Elixir, shell),
+        parts = String.split(mod, "."),
+        depth <= length(parts),
+        name = Enum.at(parts, depth - 1),
+        valid_alias_piece?("." <> name),
+        uniq: true,
+        do: %{kind: :module, name: name}
+  end
+
+  defp valid_alias_piece?(<<?., char, rest::binary>>) when char in ?A..?Z, do: valid_alias_rest?(rest)
+
+  defp valid_alias_piece?(_), do: false
+
+  defp valid_alias_rest?(<<char, rest::binary>>)
+       when char in ?A..?Z
+       when char in ?a..?z
+       when char in ?0..?9
+       when char == ?_,
+       do: valid_alias_rest?(rest)
+
+  defp valid_alias_rest?(<<>>), do: true
+  defp valid_alias_rest?(rest), do: valid_alias_piece?(rest)
+
+  ## Formatting
+
+  defp format_expansion([], _) do
+    no()
+  end
+
+  defp format_expansion([uniq], hint) do
+    case to_hint(uniq, hint) do
+      "" -> yes("", [uniq])
+      hint -> yes(hint, [uniq])
+    end
+  end
+
+  defp format_expansion([first | _] = entries, hint) do
+    binary = Enum.map(entries, & &1.name)
+    length = byte_size(hint)
+    prefix = :binary.longest_common_prefix(binary)
+
+    if prefix in [0, length] do
+      yes("", entries)
+    else
+      yes(binary_part(first.name, prefix, length - prefix), entries)
+    end
+  end
+
+  defp yes(hint, entries) do
+    {:yes, String.to_charlist(hint), entries}
+  end
+
+  defp no do
+    {:no, ~c"", []}
+  end
+
+  ## Helpers
+
+  defp usable_as_unquoted_module?(name) do
+    # Conversion to atom is not a problem because
+    # it is only called with existing modules names.
+    Macro.classify_atom(String.to_atom(name)) in [:identifier, :unquoted]
+  end
+
+  defp match_modules(hint, elixir_root?, shell) do
+    elixir_root?
+    |> get_modules(shell)
+    |> Enum.sort()
+    |> Enum.dedup()
+    |> Enum.drop_while(&(not String.starts_with?(&1, hint)))
+    |> Enum.take_while(&String.starts_with?(&1, hint))
+  end
+
+  defp get_modules(true, shell) do
+    ["Elixir.Elixir"] ++ get_modules(false, shell)
+  end
+
+  defp get_modules(false, shell) do
+    {:ok, mods} =
+      NextLS.Runtime.execute shell do
+        :code.all_loaded()
+      end
+
+    modules =
+      Enum.map(mods, &Atom.to_string(elem(&1, 0)))
+
+    {:ok, mode} = NextLS.Runtime.execute(shell, do: :code.get_mode())
+
+    case mode do
+      :interactive -> modules ++ get_modules_from_applications(shell)
+      _otherwise -> modules
+    end
+  end
+
+  defp get_modules_from_applications(shell) do
+    for [app] <- loaded_applications(shell),
+        {:ok, modules} =
+          then(NextLS.Runtime.execute(shell, do: :application.get_key(app, :modules)), fn {:ok, result} -> result end),
+        module <- modules do
+      Atom.to_string(module)
+    end
+  end
+
+  defp loaded_applications(shell) do
+    # If we invoke :application.loaded_applications/0,
+    # it can error if we don't call safe_fixtable before.
+    # Since in both cases we are reaching over the
+    # application controller internals, we choose to match
+    # for performance.
+    {:ok, apps} =
+      NextLS.Runtime.execute shell do
+        :ets.match(:ac_tab, {{:loaded, :"$1"}, :_})
+      end
+
+    apps
+  end
+
+  defp match_module_funs(runtime, mod, funs, hint, exact?) do
+    {content_type, fdocs} =
+      case NextLS.Runtime.execute(runtime, do: Code.fetch_docs(mod)) do
+        {:ok, {:docs_v1, _, _lang, content_type, _, _, fdocs}} ->
+          {content_type, fdocs}
+
+        _ ->
+          {"text/markdown", []}
+      end
+
+    for_result =
+      for {fun, arity} <- funs,
+          name = Atom.to_string(fun),
+          if(exact?, do: name == hint, else: String.starts_with?(name, hint)) do
+        doc =
+          Enum.find(fdocs, fn {{type, fname, _a}, _, _, _doc, _} ->
+            type in [:function, :macro] and to_string(fname) == name
+          end)
+
+        doc =
+          case doc do
+            {_, _, _, %{"en" => fdoc}, _} ->
+              """
+              ## #{Macro.to_string(mod)}.#{name}/#{arity}
+
+              #{NextLS.HoverHelpers.to_markdown(content_type, fdoc)}
+              """
+
+            _ ->
+              nil
+          end
+
+        %{
+          kind: :function,
+          name: name,
+          arity: arity,
+          docs: doc
+        }
+      end
+
+    Enum.sort_by(for_result, &{&1.name, &1.arity})
+  end
+
+  defp match_map_fields(map, hint) do
+    for_result =
+      for {key, value} when is_atom(key) <- Map.to_list(map),
+          key = Atom.to_string(key),
+          String.starts_with?(key, hint) do
+        %{kind: :map_key, name: key, value_is_map: is_map(value)}
+      end
+
+    Enum.sort_by(for_result, & &1.name)
+  end
+
+  defp get_module_funs(mod, shell) do
+    cond do
+      not ensure_loaded?(mod, shell) ->
+        []
+
+      docs = get_docs(mod, [:function, :macro]) ->
+        mod
+        |> exports(shell)
+        |> Kernel.--(default_arg_functions_with_doc_false(docs))
+        |> Enum.reject(&hidden_fun?(&1, docs))
+
+      true ->
+        exports(mod, shell)
+    end
+  end
+
+  defp get_module_types(mod, shell) do
+    if ensure_loaded?(mod, shell) do
+      case Code.Typespec.fetch_types(mod) do
+        {:ok, types} ->
+          for {kind, {name, _, args}} <- types,
+              kind in [:type, :opaque] do
+            {name, length(args)}
+          end
+
+        :error ->
+          []
+      end
+    else
+      []
+    end
+  end
+
+  defp get_module_callbacks(mod, shell) do
+    if ensure_loaded?(mod, shell) do
+      case Code.Typespec.fetch_callbacks(mod) do
+        {:ok, callbacks} ->
+          for {name_arity, _} <- callbacks do
+            {_kind, name, arity} = IEx.Introspection.translate_callback_name_arity(name_arity)
+
+            {name, arity}
+          end
+
+        :error ->
+          []
+      end
+    else
+      []
+    end
+  end
+
+  defp get_docs(mod, kinds, fun \\ nil) do
+    case Code.fetch_docs(mod) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        if is_nil(fun) do
+          for {{kind, _, _}, _, _, _, _} = doc <- docs, kind in kinds, do: doc
+        else
+          for {{kind, ^fun, _}, _, _, _, _} = doc <- docs, kind in kinds, do: doc
+        end
+
+      {:error, _} ->
+        nil
+    end
+  end
+
+  defp default_arg_functions_with_doc_false(docs) do
+    for {{_, fun_name, arity}, _, _, :hidden, %{defaults: count}} <- docs,
+        new_arity <- (arity - count)..arity,
+        do: {fun_name, new_arity}
+  end
+
+  defp hidden_fun?({name, arity}, docs) do
+    case Enum.find(docs, &match?({{_, ^name, ^arity}, _, _, _, _}, &1)) do
+      nil -> hd(Atom.to_charlist(name)) == ?_
+      {_, _, _, :hidden, _} -> true
+      {_, _, _, _, _} -> false
+    end
+  end
+
+  defp ensure_loaded?(Elixir, _shell), do: false
+
+  defp ensure_loaded?(mod, shell) do
+    {:ok, value} = NextLS.Runtime.execute(shell, do: Code.ensure_loaded?(mod))
+    value
+  end
+
+  ## Ad-hoc conversions
+
+  # Add extra character only if pressing tab when done
+  defp to_hint(%{kind: :module, name: hint}, hint) do
+    "."
+  end
+
+  defp to_hint(%{kind: :map_key, name: hint, value_is_map: true}, hint) do
+    "."
+  end
+
+  defp to_hint(%{kind: :file, name: hint}, hint) do
+    "\""
+  end
+
+  # Add extra character whenever possible
+  defp to_hint(%{kind: :dir, name: name}, hint) do
+    format_hint(name, hint) <> "/"
+  end
+
+  defp to_hint(%{kind: :struct, name: name}, hint) do
+    format_hint(name, hint) <> "{"
+  end
+
+  defp to_hint(%{kind: :keyword, name: name}, hint) do
+    format_hint(name, hint) <> ": "
+  end
+
+  defp to_hint(%{kind: _, name: name}, hint) do
+    format_hint(name, hint)
+  end
+
+  defp format_hint(name, hint) do
+    hint_size = byte_size(hint)
+    binary_part(name, hint_size, byte_size(name) - hint_size)
+  end
+
+  ## Evaluator interface
+
+  defp imports_from_env(_runtime) do
+    # with {evaluator, server} <- IEx.Broker.evaluator(shell),
+    #      env_fields = IEx.Evaluator.fields_from_env(evaluator, server, [:functions, :macros]),
+    #      %{functions: funs, macros: macros} <- env_fields do
+    #   funs ++ macros
+    # else
+    #   _ -> []
+    # end
+    []
+  end
+
+  defp aliases_from_env(_runtime) do
+    # with {evaluator, server} <- IEx.Broker.evaluator(shell),
+    #      %{aliases: aliases} <- IEx.Evaluator.fields_from_env(evaluator, server, [:aliases]) do
+    #   aliases
+    # else
+    #   _ -> []
+    # end
+    []
+  end
+
+  defp variables_from_binding(hint, _runtime) do
+    {:ok, ast} = Code.Fragment.container_cursor_to_quoted(hint, columns: true)
+
+    ast |> Macro.to_string() |> IO.puts()
+
+    dbg(ast, limit: :infinity)
+
+    NextLS.ASTHelpers.Variables.collect(ast)
+  end
+
+  defp value_from_binding([_var | _path], _runtime) do
+    # with {evaluator, server} <- IEx.Broker.evaluator(shell) do
+    #   IEx.Evaluator.value_from_binding(evaluator, server, var, path)
+    # else
+    #   _ -> :error
+    # end
+    []
+  end
+
+  ## Path helpers
+
+  defp path_fragment(expr), do: path_fragment(expr, [])
+  defp path_fragment([], _acc), do: []
+  defp path_fragment([?{, ?# | _rest], _acc), do: []
+  defp path_fragment([?", ?\\ | t], acc), do: path_fragment(t, [?\\, ?" | acc])
+
+  defp path_fragment([?/, ?:, x, ?" | _], acc) when x in ?a..?z or x in ?A..?Z, do: [x, ?:, ?/ | acc]
+
+  defp path_fragment([?/, ?., ?" | _], acc), do: [?., ?/ | acc]
+  defp path_fragment([?/, ?" | _], acc), do: [?/ | acc]
+  defp path_fragment([?" | _], _acc), do: []
+  defp path_fragment([h | t], acc), do: path_fragment(t, [h | acc])
+
+  defp expand_path(path) do
+    path
+    |> List.to_string()
+    |> ls_prefix()
+    |> Enum.map(fn path ->
+      %{
+        kind: if(File.dir?(path), do: :dir, else: :file),
+        name: Path.basename(path)
+      }
+    end)
+    |> format_expansion(path_hint(path))
+  end
+
+  defp path_hint(path) do
+    if List.last(path) in [?/, ?\\] do
+      ""
+    else
+      Path.basename(path)
+    end
+  end
+
+  defp prefix_from_dir(".", <<c, _::binary>>) when c != ?., do: ""
+  defp prefix_from_dir(dir, _fragment), do: dir
+
+  defp ls_prefix(path) do
+    dir = Path.dirname(path)
+    prefix = prefix_from_dir(dir, path)
+
+    case File.ls(dir) do
+      {:ok, list} ->
+        list
+        |> Enum.map(&Path.join(prefix, &1))
+        |> Enum.filter(&String.starts_with?(&1, path))
+
+      _ ->
+        []
+    end
+  end
+end

--- a/lib/next_ls/autocomplete.ex
+++ b/lib/next_ls/autocomplete.ex
@@ -342,6 +342,7 @@ defmodule NextLS.Autocomplete do
     format_expansion(refs)
   end
 
+  @dialyzer {:nowarn_function, expand_container_context: 4}
   defp expand_container_context(code, context, hint, shell) do
     case container_context(code, shell) do
       {:map, map, pairs} when context == :expr ->
@@ -440,6 +441,8 @@ defmodule NextLS.Autocomplete do
     end
   end
 
+
+  @dialyzer {:nowarn_function, container_context_map: 4}
   defp container_context_map(cursor, pairs, variable, shell) do
     with {pairs, [^cursor]} <- Enum.split(pairs, -1),
          {:ok, map} when is_map(map) <- value_from_binding([variable], shell),

--- a/lib/next_ls/db.ex
+++ b/lib/next_ls/db.ex
@@ -195,12 +195,10 @@ defmodule NextLS.DB do
     case Exqlite.Basic.exec(conn, query, args) do
       {:error, %{message: message, statement: statement}, _} ->
         NextLS.Logger.warning(logger, """
-        ┌─────────────
-        │sqlite3 error: #{message}
-        │
-        │statement: #{statement}
-        │arguments: #{inspect(args)}
-        └─────────────
+        sqlite3 error: #{message}
+
+        statement: #{statement}
+        arguments: #{inspect(args)}
         """)
 
         {:error, message}

--- a/lib/next_ls/db.ex
+++ b/lib/next_ls/db.ex
@@ -195,10 +195,12 @@ defmodule NextLS.DB do
     case Exqlite.Basic.exec(conn, query, args) do
       {:error, %{message: message, statement: statement}, _} ->
         NextLS.Logger.warning(logger, """
-        sqlite3 error: #{message}
-
-        statement: #{statement}
-        arguments: #{inspect(args)}
+        ┌─────────────
+        │sqlite3 error: #{message}
+        │
+        │statement: #{statement}
+        │arguments: #{inspect(args)}
+        └─────────────
         """)
 
         {:error, message}

--- a/lib/next_ls/helpers/ast_helpers/variables.ex
+++ b/lib/next_ls/helpers/ast_helpers/variables.ex
@@ -31,8 +31,7 @@ defmodule NextLS.ASTHelpers.Variables do
 
   def collect(ast) do
     {_, %{cursor: cursor, symbols: symbols}} =
-      ast
-      |> Macro.traverse(%{vars: [], symbols: %{}, sym_ranges: [], scope: []}, &prewalk/2, &postwalk/2)
+      Macro.traverse(ast, %{vars: [], symbols: %{}, sym_ranges: [], scope: []}, &prewalk/2, &postwalk/2)
 
     cscope = Enum.reverse(cursor.scope)
 

--- a/lib/next_ls/helpers/ast_helpers/variables.ex
+++ b/lib/next_ls/helpers/ast_helpers/variables.ex
@@ -19,7 +19,6 @@ defmodule NextLS.ASTHelpers.Variables do
             &prewalk/2,
             &postwalk/2
           )
-          |> dbg(limit: :infinity)
 
         Enum.find_value(vars, fn %{name: name, sym_range: range, ref_range: ref_range} ->
           if position_in_range?(position, ref_range), do: {name, range}, else: nil
@@ -34,7 +33,6 @@ defmodule NextLS.ASTHelpers.Variables do
     {_, %{cursor: cursor, symbols: symbols}} =
       ast
       |> Macro.traverse(%{vars: [], symbols: %{}, sym_ranges: [], scope: []}, &prewalk/2, &postwalk/2)
-      # |> dbg(limit: :infinity)
 
     cscope = Enum.reverse(cursor.scope)
 

--- a/lib/next_ls/helpers/ast_helpers/variables.ex
+++ b/lib/next_ls/helpers/ast_helpers/variables.ex
@@ -29,16 +29,18 @@ defmodule NextLS.ASTHelpers.Variables do
     end
   end
 
-  def collect(ast) do
-    {_, %{cursor: cursor, symbols: symbols}} =
-      Macro.traverse(ast, %{vars: [], symbols: %{}, sym_ranges: [], scope: []}, &prewalk/2, &postwalk/2)
+  # TODO: Potentially use when adding local variables as completion candidates
 
-    cscope = Enum.reverse(cursor.scope)
+  # def collect(ast) do
+  #   {_, %{cursor: cursor, symbols: symbols}} =
+  #     Macro.traverse(ast, %{vars: [], symbols: %{}, sym_ranges: [], scope: []}, &prewalk/2, &postwalk/2)
 
-    for {name, defs} <- symbols, def <- defs, List.starts_with?(cscope, Enum.reverse(def.scope)) do
-      to_string(name)
-    end
-  end
+  #   cscope = Enum.reverse(cursor.scope)
+
+  #   for {name, defs} <- symbols, def <- defs, List.starts_with?(cscope, Enum.reverse(def.scope)) do
+  #     to_string(name)
+  #   end
+  # end
 
   @spec list_variable_references(String.t(), {integer(), integer()}) :: [{atom(), {Range.t(), Range.t()}}]
   def list_variable_references(file, position) do

--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -38,6 +38,13 @@ defmodule NextLS.Runtime do
     GenServer.call(server, {:compile, opts}, :infinity)
   end
 
+  defmacro execute!(runtime, block) do
+    quote do
+      {:ok, result} = NextLS.Runtime.execute(unquote_splicing([runtime, block]))
+      result
+    end
+  end
+
   defmacro execute(runtime, do: block) do
     exprs =
       case block do

--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -33,8 +33,34 @@ defmodule NextLS.Runtime do
     end
   end
 
+  @spec compile(pid(), Keyword.t()) :: any()
   def compile(server, opts \\ []) do
     GenServer.call(server, {:compile, opts}, :infinity)
+  end
+
+  defmacro execute(runtime, do: block) do
+    exprs =
+      case block do
+        {:__block__, _, exprs} -> exprs
+        expr -> [expr]
+      end
+
+    for expr <- exprs, reduce: quote(do: :ok) do
+      ast ->
+        mfa =
+          case expr do
+            {{:., _, [mod, func]}, _, args} ->
+              [mod, func, args]
+
+            {_func, _, _args} ->
+              raise "#{Macro.to_string(__MODULE__)}.execute/2 cannot be called with local functions"
+          end
+
+        quote do
+          unquote(ast)
+          NextLS.Runtime.call(unquote(runtime), {unquote_splicing(mfa)})
+        end
+    end
   end
 
   @impl GenServer

--- a/lib/next_ls/snippet.ex
+++ b/lib/next_ls/snippet.ex
@@ -1,0 +1,189 @@
+defmodule NextLS.Snippet do
+  @moduledoc false
+
+  def get("defmodule" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      defmodule ${1:ModuleName} do
+        $0
+      end
+      """
+    }
+  end
+
+  def get("defstruct" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      defstruct [${1:field}: ${2:default}]
+      """
+    }
+  end
+
+  def get("defprotocol" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      defprotocol ${1:ProtocolName} do
+        def ${2:function_name}(${3:parameter_name})
+      end
+      """
+    }
+  end
+
+  def get("defimpl" = label, nil) do
+    [
+      %GenLSP.Structures.CompletionItem{
+        label: label,
+        kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+        insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+        insert_text: """
+        defimpl ${1:ProtocolName} do
+          def ${2:function_name}(${3:parameter_name}) do
+            $0
+          end
+        end
+        """
+      },
+      %GenLSP.Structures.CompletionItem{
+        label: label <> "f",
+        kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+        insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+        insert_text: """
+        defimpl ${1:ProtocolName}, for: ${2:StructName} do
+          def ${3:function_name}(${4:parameter_name}) do
+            $0
+          end
+        end
+        """
+      }
+    ]
+  end
+
+  def get("def" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      def ${1:function_name}(${2:parameter_1}) do
+        $0
+      end
+      """
+    }
+  end
+
+  def get("defp" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      defp ${1:function_name}(${2:parameter_1}) do
+        $0
+      end
+      """
+    }
+  end
+
+  def get("defmacro" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      defmacro ${1:macro_name}(${2:parameter_1}) do
+        quote do
+          $0
+        end
+      end
+      """
+    }
+  end
+
+  def get("defmacrop" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      defmacrop ${1:macro_name}(${2:parameter_1}) do
+        quote do
+          $0
+        end
+      end
+      """
+    }
+  end
+
+  def get("for" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      for ${2:item} <- ${1:enumerable} do
+        $0
+      end
+      """
+    }
+  end
+
+  def get("with" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      with ${2:match} <- ${1:argument} do
+        $0
+      end
+      """
+    }
+  end
+
+  def get("case" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      case ${1:argument} do
+        ${2:match} ->
+          ${0::ok}
+
+         _ ->
+          :error
+      end
+      """
+    }
+  end
+
+  def get("cond" = label, nil) do
+    %GenLSP.Structures.CompletionItem{
+      label: label,
+      kind: GenLSP.Enumerations.CompletionItemKind.snippet(),
+      insert_text_format: GenLSP.Enumerations.InsertTextFormat.snippet(),
+      insert_text: """
+      cond do
+        ${1:condition} ->
+          ${0::ok}
+
+        true ->
+          ${2::error}
+      end
+      """
+    }
+  end
+
+  def get(_label, _trigger_character) do
+    nil
+  end
+end

--- a/test/next_ls/autocomplete_test.exs
+++ b/test/next_ls/autocomplete_test.exs
@@ -86,37 +86,37 @@ defmodule NextLS.AutocompleteTest do
   end
 
   test "Erlang module completion", %{runtime: runtime} do
-    assert expand(runtime, ~c":zl") == {:yes, ~c"ib", [%{name: "zlib", kind: :module}]}
+    assert expand(runtime, ~c":zl") == {:yes, [%{name: "zlib", kind: :module}]}
   end
 
   test "Erlang module no completion", %{runtime: runtime} do
-    assert expand(runtime, ~c":unknown") == {:no, ~c"", []}
+    assert expand(runtime, ~c":unknown") == {:no, []}
   end
 
   test "Erlang module multiple values completion", %{runtime: runtime} do
-    {:yes, ~c"", list} = expand(runtime, ~c":logger")
+    {:yes, list} = expand(runtime, ~c":logger")
     assert %{name: "logger", kind: :module} in list
     assert %{name: "logger_proxy", kind: :module} in list
   end
 
   test "Erlang root completion", %{runtime: runtime} do
-    {:yes, ~c"", list} = expand(runtime, ~c":")
+    {:yes, list} = expand(runtime, ~c":")
     assert is_list(list)
     assert %{name: "lists", kind: :module} in list
     assert %{name: "Elixir.List", kind: :module} not in list
   end
 
   test "Elixir proxy", %{runtime: runtime} do
-    {:yes, ~c"", list} = expand(runtime, ~c"E")
+    {:yes, list} = expand(runtime, ~c"E")
     assert %{name: "Elixir", kind: :module} in list
   end
 
   test "Elixir completion", %{runtime: runtime} do
     assert expand(runtime, ~c"En") ==
-             {:yes, ~c"um", [%{name: "Enum", kind: :module}, %{name: "Enumerable", kind: :module}]}
+             {:yes, [%{name: "Enum", kind: :module}, %{name: "Enumerable", kind: :module}]}
 
     assert expand(runtime, ~c"Enumera") ==
-             {:yes, ~c"ble", [%{name: "Enumerable", kind: :module}]}
+             {:yes, [%{name: "Enumerable", kind: :module}]}
   end
 
   # test "Elixir type completion", %{runtime: runtime} do
@@ -158,11 +158,11 @@ defmodule NextLS.AutocompleteTest do
 
   test "Elixir completion on modules from load path", %{runtime: runtime} do
     assert expand(runtime, ~c"Str") ==
-             {:yes, [],
+             {:yes,
               [%{name: "Stream", kind: :module}, %{name: "String", kind: :module}, %{name: "StringIO", kind: :module}]}
 
     assert expand(runtime, ~c"Ma") ==
-             {:yes, ~c"",
+             {:yes,
               [
                 %{name: "Macro", kind: :module},
                 %{name: "Map", kind: :module},
@@ -170,7 +170,7 @@ defmodule NextLS.AutocompleteTest do
                 %{name: "MatchError", kind: :module}
               ]}
 
-    assert expand(runtime, ~c"Dic") == {:yes, ~c"t", [%{name: "Dict", kind: :module}]}
+    assert expand(runtime, ~c"Dic") == {:yes, [%{name: "Dict", kind: :module}]}
 
     # FIXME: ExUnit is not available when the MIX_ENV is dev. Need to figure out a way to make it complete later
     # assert expand(runtime, ~c"Ex") == {:yes, [], [~c"ExUnit", ~c"Exception"]}
@@ -242,45 +242,45 @@ defmodule NextLS.AutocompleteTest do
   # end
 
   test "Elixir no completion", %{runtime: runtime} do
-    assert expand(runtime, ~c".") == {:no, ~c"", []}
-    assert expand(runtime, ~c"Xyz") == {:no, ~c"", []}
-    assert expand(runtime, ~c"x.Foo") == {:no, ~c"", []}
-    assert expand(runtime, ~c"x.Foo.get_by") == {:no, ~c"", []}
-    assert expand(runtime, ~c"@foo.bar") == {:no, ~c"", []}
+    assert expand(runtime, ~c".") == {:no, []}
+    assert expand(runtime, ~c"Xyz") == {:no, []}
+    assert expand(runtime, ~c"x.Foo") == {:no, []}
+    assert expand(runtime, ~c"x.Foo.get_by") == {:no, []}
+    assert expand(runtime, ~c"@foo.bar") == {:no, []}
   end
 
   test "Elixir root submodule completion", %{runtime: runtime} do
-    assert expand(runtime, ~c"Elixir.Acce") == {:yes, ~c"ss", [%{name: "Access", kind: :module}]}
+    assert expand(runtime, ~c"Elixir.Acce") == {:yes, [%{name: "Access", kind: :module}]}
   end
 
   test "Elixir submodule completion", %{runtime: runtime} do
-    assert expand(runtime, ~c"String.Cha") == {:yes, ~c"rs", [%{name: "Chars", kind: :module}]}
+    assert expand(runtime, ~c"String.Cha") == {:yes, [%{name: "Chars", kind: :module}]}
   end
 
   test "Elixir submodule no completion", %{runtime: runtime} do
-    assert expand(runtime, ~c"IEx.Xyz") == {:no, ~c"", []}
+    assert expand(runtime, ~c"IEx.Xyz") == {:no, []}
   end
 
   test "function completion", %{runtime: runtime} do
-    assert {:yes, ~c"rsion", [%{arity: 0, name: "version", docs: _, kind: :function}]} = expand(runtime, ~c"System.ve")
+    assert {:yes, [%{arity: 0, name: "version", docs: _, kind: :function}]} = expand(runtime, ~c"System.ve")
 
-    assert {:yes, ~c"ms", [%{arity: 1, name: "fun2ms", docs: _, kind: :function}]} = expand(runtime, ~c":ets.fun2")
+    assert {:yes, [%{arity: 1, name: "fun2ms", docs: _, kind: :function}]} = expand(runtime, ~c":ets.fun2")
   end
 
   test "function completion with arity", %{runtime: runtime} do
-    assert {:yes, ~c"",
+    assert {:yes,
             [
               %{arity: 1, name: "printable?", docs: _, kind: :function},
               %{arity: 2, name: "printable?", docs: _, kind: :function}
             ]} = expand(runtime, ~c"String.printable?")
 
-    assert {:yes, ~c"",
+    assert {:yes,
             [
               %{arity: 1, name: "printable?", docs: _, kind: :function},
               %{arity: 2, name: "printable?", docs: _, kind: :function}
             ]} = expand(runtime, ~c"String.printable?/")
 
-    assert {:yes, ~c"",
+    assert {:yes,
             [
               %{arity: 1, name: "count", docs: _, kind: :function},
               %{arity: 2, name: "count", docs: _, kind: :function},
@@ -288,7 +288,7 @@ defmodule NextLS.AutocompleteTest do
               %{arity: 3, name: "count_until", docs: _, kind: :function}
             ]} = expand(runtime, ~c"Enum.count")
 
-    assert {:yes, ~c"",
+    assert {:yes,
             [
               %{arity: 1, name: "count", docs: _, kind: :function},
               %{arity: 2, name: "count", docs: _, kind: :function}
@@ -367,22 +367,28 @@ defmodule NextLS.AutocompleteTest do
   test "unbound variables is not supported", %{runtime: runtime} do
     prev = "num = 5"
 
-    assert expand(runtime, ~c"#{prev}\nother_var.f") == {:no, ~c"", []}
+    assert expand(runtime, ~c"#{prev}\nother_var.f") == {:no, []}
 
     # assert expand(runtime, ~c"a.b.c.d") == {:no, ~c"", []}
   end
 
   test "macro completion", %{runtime: runtime} do
-    {:yes, ~c"", list} = expand(runtime, ~c"Kernel.is_")
+    {:yes, list} = expand(runtime, ~c"Kernel.is_")
     assert is_list(list)
   end
 
   # NOTE: special forms are a.. special case, so they work ootb
   test "imports completion", %{runtime: runtime} do
-    {:yes, ~c"", list} = expand(runtime, ~c"")
+    {:yes, list} = expand(runtime, ~c"")
     assert is_list(list)
-    assert %{name: "unquote", arity: 1, kind: :function, docs: nil} in list
-    assert %{name: "try", arity: 1, kind: :function, docs: nil} in list
+
+    Enum.any?(list, fn i ->
+      match?(%{name: "unquote", arity: 1, kind: :function, docs: _}, i)
+    end)
+
+    Enum.any?(list, fn i ->
+      match?(%{name: "try", arity: 1, kind: :function, docs: _}, i)
+    end)
   end
 
   # TODO: locals
@@ -435,24 +441,23 @@ defmodule NextLS.AutocompleteTest do
   # end
 
   test "kernel special form completion", %{runtime: runtime} do
-    assert expand(runtime, ~c"unquote_spl") ==
-             {:yes, ~c"icing", [%{arity: 1, name: "unquote_splicing", docs: nil, kind: :function}]}
+    assert {:yes, [%{arity: 1, name: "unquote_splicing", docs: _, kind: :function}]} = expand(runtime, ~c"unquote_spl")
   end
 
   test "completion inside expression", %{runtime: runtime} do
     assert expand(runtime, ~c"1 En") ==
-             {:yes, ~c"um", [%{name: "Enum", kind: :module}, %{name: "Enumerable", kind: :module}]}
+             {:yes, [%{name: "Enum", kind: :module}, %{name: "Enumerable", kind: :module}]}
 
     assert expand(runtime, ~c"Test(En") ==
-             {:yes, ~c"um", [%{name: "Enum", kind: :module}, %{name: "Enumerable", kind: :module}]}
+             {:yes, [%{name: "Enum", kind: :module}, %{name: "Enumerable", kind: :module}]}
 
-    assert expand(runtime, ~c"Test :zl") == {:yes, ~c"ib", [%{name: "zlib", kind: :module}]}
-    assert expand(runtime, ~c"[:zl") == {:yes, ~c"ib", [%{name: "zlib", kind: :module}]}
-    assert expand(runtime, ~c"{:zl") == {:yes, ~c"ib", [%{name: "zlib", kind: :module}]}
+    assert expand(runtime, ~c"Test :zl") == {:yes, [%{name: "zlib", kind: :module}]}
+    assert expand(runtime, ~c"[:zl") == {:yes, [%{name: "zlib", kind: :module}]}
+    assert expand(runtime, ~c"{:zl") == {:yes, [%{name: "zlib", kind: :module}]}
   end
 
   test "Elixir completion sublevel", %{runtime: runtime} do
-    assert expand(runtime, ~c"SublevelTest.") == {:yes, ~c"LevelA", [%{name: "LevelA", kind: :module}]}
+    assert expand(runtime, ~c"SublevelTest.") == {:yes, [%{name: "LevelA", kind: :module}]}
   end
 
   # TODO: aliases
@@ -500,20 +505,20 @@ defmodule NextLS.AutocompleteTest do
   # end
 
   test "completion for struct names", %{runtime: runtime} do
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"%")
+    assert {:yes, entries} = expand(runtime, ~c"%")
     assert %{name: "URI", kind: :struct} in entries
     assert %{name: "IEx.History", kind: :struct} in entries
     assert %{name: "IEx.Server", kind: :struct} in entries
 
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"%IEx.")
+    assert {:yes, entries} = expand(runtime, ~c"%IEx.")
     assert %{name: "IEx.History", kind: :struct} in entries
     assert %{name: "IEx.Server", kind: :struct} in entries
 
     assert expand(runtime, ~c"%Something.Fo") ==
-             {:yes, ~c"o.MyStruct{", [%{name: "Something.Foo.MyStruct", kind: :struct}]}
+             {:yes, [%{name: "Something.Foo.MyStruct", kind: :struct}]}
 
     assert expand(runtime, ~c"%Something.Foo.MyStr") ==
-             {:yes, ~c"uct{", [%{name: "Something.Foo.MyStruct", kind: :struct}]}
+             {:yes, [%{name: "Something.Foo.MyStruct", kind: :struct}]}
 
     # TODO: aliases
     # prev = "alias NextLS.AutocompleteTest.MyStruct"
@@ -521,31 +526,31 @@ defmodule NextLS.AutocompleteTest do
   end
 
   test "completion for struct keys", %{runtime: runtime} do
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{")
+    assert {:yes, entries} = expand(runtime, ~c"%URI{")
     assert %{name: "path", kind: :keyword} in entries
     assert %{name: "query", kind: :keyword} in entries
 
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{path: \"foo\",")
+    assert {:yes, entries} = expand(runtime, ~c"%URI{path: \"foo\",")
     assert %{name: "path", kind: :keyword} not in entries
     assert %{name: "query", kind: :keyword} in entries
 
-    assert {:yes, ~c"ry: ", [%{name: "query", kind: :keyword}]} = expand(runtime, ~c"%URI{path: \"foo\", que")
-    assert {:no, [], []} = expand(runtime, ~c"%URI{path: \"foo\", unkno")
-    assert {:no, [], []} = expand(runtime, ~c"%Unkown{path: \"foo\", unkno")
+    assert {:yes, [%{name: "query", kind: :keyword}]} = expand(runtime, ~c"%URI{path: \"foo\", que")
+    assert {:no, []} = expand(runtime, ~c"%URI{path: \"foo\", unkno")
+    assert {:no, []} = expand(runtime, ~c"%Unkown{path: \"foo\", unkno")
   end
 
   test "completion for struct keys in update syntax", %{runtime: runtime} do
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{var | ")
+    assert {:yes, entries} = expand(runtime, ~c"%URI{var | ")
     assert %{name: "path", kind: :keyword} in entries
     assert %{name: "query", kind: :keyword} in entries
 
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{var | path: \"foo\",")
+    assert {:yes, entries} = expand(runtime, ~c"%URI{var | path: \"foo\",")
     assert %{name: "path", kind: :keyword} not in entries
     assert %{name: "query", kind: :keyword} in entries
 
-    assert {:yes, ~c"ry: ", [%{name: "query", kind: :keyword}]} = expand(runtime, ~c"%URI{var | path: \"foo\", que")
-    assert {:no, [], []} = expand(runtime, ~c"%URI{var | path: \"foo\", unkno")
-    assert {:no, [], []} = expand(runtime, ~c"%Unkown{var | path: \"foo\", unkno")
+    assert {:yes, [%{name: "query", kind: :keyword}]} = expand(runtime, ~c"%URI{var | path: \"foo\", que")
+    assert {:no, []} = expand(runtime, ~c"%URI{var | path: \"foo\", unkno")
+    assert {:no, []} = expand(runtime, ~c"%Unkown{var | path: \"foo\", unkno")
   end
 
   # TODO: this might be possible
@@ -560,8 +565,8 @@ defmodule NextLS.AutocompleteTest do
   #   assert ~c"other:" in entries
 
   #   assert {:yes, ~c"er: ", []} = expand(runtime, ~c"#{prev}\n%{map | some: \"foo\", oth")
-  #   assert {:no, [], []} = expand(runtime, ~c"#{prev}\n%{map | some: \"foo\", unkno")
-  #   assert {:no, [], []} = expand(runtime, ~c"#{prev}\n%{unknown | some: \"foo\", unkno")
+  #   assert {:no,  []} = expand(runtime, ~c"#{prev}\n%{map | some: \"foo\", unkno")
+  #   assert {:no,  []} = expand(runtime, ~c"#{prev}\n%{unknown | some: \"foo\", unkno")
   # end
 
   # TODO: this might be possible
@@ -571,39 +576,39 @@ defmodule NextLS.AutocompleteTest do
   # end
 
   test "completion for bitstring modifiers", %{runtime: runtime} do
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"<<foo::")
+    assert {:yes, entries} = expand(runtime, ~c"<<foo::")
     assert %{name: "integer", kind: :variable} in entries
-    assert %{name: "size", kind: :function, arity: 1} in entries
+    assert %{name: "size", kind: :function, arity: 1, docs: nil} in entries
 
-    assert {:yes, ~c"eger", [%{name: "integer", kind: :variable}]} = expand(runtime, ~c"<<foo::int")
+    assert {:yes, [%{name: "integer", kind: :variable}]} = expand(runtime, ~c"<<foo::int")
 
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"<<foo::integer-")
+    assert {:yes, entries} = expand(runtime, ~c"<<foo::integer-")
     refute %{name: "integer", kind: :variable} in entries
     assert %{name: "little", kind: :variable} in entries
-    assert %{name: "size", kind: :function, arity: 1} in entries
+    assert %{name: "size", kind: :function, arity: 1, docs: nil} in entries
 
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"<<foo::integer-little-")
+    assert {:yes, entries} = expand(runtime, ~c"<<foo::integer-little-")
     refute %{name: "integer", kind: :variable} in entries
     refute %{name: "little", kind: :variable} in entries
-    assert %{name: "size", kind: :function, arity: 1} in entries
+    assert %{name: "size", kind: :function, arity: 1, docs: nil} in entries
   end
 
   test "completion for aliases in special forms", %{runtime: runtime} do
-    assert {:yes, ~c"", entries} = expand(runtime, ~c"alias ")
+    assert {:yes, entries} = expand(runtime, ~c"alias ")
     assert %{name: "Atom", kind: :module} in entries
     refute %{name: "is_atom", kind: :function, arity: 1} in entries
 
-    assert {:yes, ~c"Range", [%{name: "Range", kind: :module}]} = expand(runtime, ~c"alias Date.")
+    assert {:yes, [%{name: "Range", kind: :module}]} = expand(runtime, ~c"alias Date.")
   end
 
   test "ignore invalid Elixir module literals", %{runtime: runtime} do
-    assert expand(runtime, ~c"NextLS.AutocompleteTest.Unicod") == {:no, ~c"", []}
+    assert expand(runtime, ~c"NextLS.AutocompleteTest.Unicod") == {:no, []}
   end
 
   test "signature help for functions and macros", %{runtime: runtime} do
-    assert expand(runtime, ~c"String.graphemes(") == {:yes, ~c"", ["graphemes(string)"]}
+    assert expand(runtime, ~c"String.graphemes(") == {:yes, ["graphemes(string)"]}
     # TODO: needs the kernel
-    # assert expand(runtime, ~c"def ") == {:yes, ~c"", [~c"def(call, expr \\\\ nil)"]}
+    # assert expand(runtime, ~c"def ") == {:yes,  [~c"def(call, expr \\\\ nil)"]}
 
     # TODO: locals
     # prev = "import Enum; import Protocol"
@@ -612,10 +617,10 @@ defmodule NextLS.AutocompleteTest do
     #          send(self(), expand(runtime, ~c"reduce("))
     #        end) == "\nreduce(enumerable, acc, fun)"
 
-    # assert_received {:yes, ~c"", [~c"reduce(enumerable, fun)"]}
+    # assert_received {:yes,  [~c"reduce(enumerable, fun)"]}
 
-    # assert expand(runtime, ~c"take(") == {:yes, ~c"", [~c"take(enumerable, amount)"]}
-    # assert expand(runtime, ~c"derive(") == {:yes, ~c"", [~c"derive(protocol, module, options \\\\ [])"]}
+    # assert expand(runtime, ~c"take(") == {:yes,  [~c"take(enumerable, amount)"]}
+    # assert expand(runtime, ~c"derive(") == {:yes,  [~c"derive(protocol, module, options \\\\ [])"]}
 
     # defmodule NoDocs do
     #   @moduledoc false
@@ -640,18 +645,18 @@ defmodule NextLS.AutocompleteTest do
     assert expand(runtime, ~c"Path.join(\"./\", is_") == expand(runtime, ~c"is_")
 
     assert expand(runtime, ~c"\"#{dir}/") == path_autocompletion(dir)
-    assert expand(runtime, ~c"\"#{dir}/sin") == {:yes, ~c"gle1", [%{name: "single1", kind: :file}]}
-    assert expand(runtime, ~c"\"#{dir}/single1") == {:yes, ~c"\"", [%{name: "single1", kind: :file}]}
+    assert expand(runtime, ~c"\"#{dir}/sin") == {:yes, [%{name: "single1", kind: :file}]}
+    assert expand(runtime, ~c"\"#{dir}/single1") == {:yes, [%{name: "single1", kind: :file}]}
 
     assert expand(runtime, ~c"\"#{dir}/fi") ==
-             {:yes, ~c"le", [%{name: "file2", kind: :file}, %{name: "file1", kind: :file}]}
+             {:yes, [%{name: "file2", kind: :file}, %{name: "file1", kind: :file}]}
 
     assert expand(runtime, ~c"\"#{dir}/file") == path_autocompletion(dir, "file")
-    assert expand(runtime, ~c"\"#{dir}/d") == {:yes, ~c"ir/", [%{name: "dir", kind: :dir}]}
-    assert expand(runtime, ~c"\"#{dir}/dir") == {:yes, ~c"/", [%{name: "dir", kind: :dir}]}
+    assert expand(runtime, ~c"\"#{dir}/d") == {:yes, [%{name: "dir/", kind: :dir}]}
+    assert expand(runtime, ~c"\"#{dir}/dir") == {:yes, [%{name: "dir/", kind: :dir}]}
 
     assert expand(runtime, ~c"\"#{dir}/dir/") ==
-             {:yes, ~c"file", [%{name: "file3", kind: :file}, %{name: "file4", kind: :file}]}
+             {:yes, [%{name: "file3", kind: :file}, %{name: "file4", kind: :file}]}
 
     assert expand(runtime, ~c"\"#{dir}/dir/file") == dir |> Path.join("dir") |> path_autocompletion("file")
   end
@@ -662,12 +667,12 @@ defmodule NextLS.AutocompleteTest do
     |> Stream.filter(&String.starts_with?(&1, hint))
     |> Enum.map(fn file ->
       kind = if File.dir?(Path.join(dir, file)), do: :dir, else: :file
-      name = if kind == :dir, do: file <> "/", else: file
+      name = if kind == :dir and not String.ends_with?(file, "/"), do: file <> "/", else: file
       %{name: name, kind: kind}
     end)
     |> case do
-      [] -> {:no, ~c"", []}
-      list -> {:yes, ~c"", list}
+      [] -> {:no, []}
+      list -> {:yes, list}
     end
   end
 end

--- a/test/next_ls/autocomplete_test.exs
+++ b/test/next_ls/autocomplete_test.exs
@@ -1,0 +1,622 @@
+defmodule NextLS.AutocompleteTest do
+  use ExUnit.Case, async: true
+
+  import NextLS.Support.Utils
+
+  alias NextLS.Runtime
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    File.write!(Path.join(tmp_dir, "mix.exs"), mix_exs())
+    File.mkdir_p!(Path.join(tmp_dir, "lib"))
+
+    File.write!(Path.join(tmp_dir, "lib/bar.ex"), """
+    defmodule Bar do
+      defstruct [:foo]
+
+      def foo(arg1) do
+      end
+    end
+    """)
+
+    me = self()
+
+    {:ok, logger} =
+      Task.start_link(fn ->
+        recv = fn recv ->
+          receive do
+            {:"$gen_cast", msg} -> send(me, msg)
+          end
+
+          recv.(recv)
+        end
+
+        recv.(recv)
+      end)
+
+    {:ok, broker} =
+      Task.start_link(fn ->
+        recv = fn recv ->
+          receive do
+            msg ->
+              dbg(msg)
+              nil
+          end
+
+          recv.(recv)
+        end
+
+        recv.(recv)
+      end)
+
+    on_init = fn msg -> send(me, msg) end
+    start_supervised!({Registry, keys: :duplicate, name: __MODULE__.Registry})
+    tvisor = start_supervised!(Task.Supervisor)
+
+    cwd = tmp_dir
+
+    pid =
+      start_supervised!(
+        {Runtime,
+         name: "my_proj",
+         on_initialized: on_init,
+         task_supervisor: tvisor,
+         working_dir: cwd,
+         uri: "file://#{cwd}",
+         parent: self(),
+         logger: logger,
+         db: :some_db,
+         mix_env: "dev",
+         mix_target: "host",
+         registry: __MODULE__.Registry}
+      )
+
+    Process.link(pid)
+
+    assert_receive :ready
+
+    Process.put(:broker, broker)
+
+    [runtime: pid, broker: broker]
+  end
+
+  defp expand(runtime, expr) do
+    NextLS.Autocomplete.expand(Enum.reverse(expr), runtime)
+  end
+
+  test "Erlang module completion", %{runtime: runtime} do
+    assert expand(runtime, ~c":zl") == {:yes, ~c"ib", []}
+  end
+
+  test "Erlang module no completion", %{runtime: runtime} do
+    assert expand(runtime, ~c":unknown") == {:no, ~c"", []}
+  end
+
+  test "Erlang module multiple values completion", %{runtime: runtime} do
+    {:yes, ~c"", list} = expand(runtime, ~c":logger")
+    assert ~c"logger" in list
+    assert ~c"logger_proxy" in list
+  end
+
+  test "Erlang root completion", %{runtime: runtime} do
+    {:yes, ~c"", list} = expand(runtime, ~c":")
+    assert is_list(list)
+    assert ~c"lists" in list
+    assert ~c"Elixir.List" not in list
+  end
+
+  test "Elixir proxy", %{runtime: runtime} do
+    {:yes, ~c"", list} = expand(runtime, ~c"E")
+    assert ~c"Elixir" in list
+  end
+
+  test "Elixir completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"En") == {:yes, ~c"um", []}
+    assert expand(runtime, ~c"Enumera") == {:yes, ~c"ble", []}
+  end
+
+  test "Elixir type completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"t :gen_ser") == {:yes, ~c"ver", []}
+    assert expand(runtime, ~c"t String") == {:yes, ~c"", [~c"String", ~c"StringIO"]}
+
+    assert expand(runtime, ~c"t String.") ==
+             {:yes, ~c"", [~c"codepoint/0", ~c"grapheme/0", ~c"pattern/0", ~c"t/0"]}
+
+    assert expand(runtime, ~c"t String.grap") == {:yes, ~c"heme", []}
+    assert expand(runtime, ~c"t  String.grap") == {:yes, ~c"heme", []}
+    assert {:yes, ~c"", [~c"date_time/0" | _]} = expand(runtime, ~c"t :file.")
+    assert expand(runtime, ~c"t :file.n") == {:yes, ~c"ame", []}
+  end
+
+  test "Elixir callback completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"b :strin") == {:yes, ~c"g", []}
+    assert expand(runtime, ~c"b String") == {:yes, ~c"", [~c"String", ~c"StringIO"]}
+    assert expand(runtime, ~c"b String.") == {:no, ~c"", []}
+    assert expand(runtime, ~c"b Access.") == {:yes, ~c"", [~c"fetch/2", ~c"get_and_update/3", ~c"pop/2"]}
+    assert expand(runtime, ~c"b GenServer.term") == {:yes, ~c"inate", []}
+    assert expand(runtime, ~c"b   GenServer.term") == {:yes, ~c"inate", []}
+    assert expand(runtime, ~c"b :gen_server.handle_in") == {:yes, ~c"fo", []}
+  end
+
+  test "Elixir helper completion with parentheses", %{runtime: runtime} do
+    assert expand(runtime, ~c"t(:gen_ser") == {:yes, ~c"ver", []}
+    assert expand(runtime, ~c"t(String") == {:yes, ~c"", [~c"String", ~c"StringIO"]}
+
+    assert expand(runtime, ~c"t(String.") ==
+             {:yes, ~c"", [~c"codepoint/0", ~c"grapheme/0", ~c"pattern/0", ~c"t/0"]}
+
+    assert expand(runtime, ~c"t(String.grap") == {:yes, ~c"heme", []}
+  end
+
+  test "Elixir completion with self", %{runtime: runtime} do
+    assert expand(runtime, ~c"Enumerable") == {:yes, ~c".", []}
+  end
+
+  test "Elixir completion on modules from load path", %{runtime: runtime} do
+    assert expand(runtime, ~c"Str") == {:yes, [], [~c"Stream", ~c"String", ~c"StringIO"]}
+    assert expand(runtime, ~c"Ma") == {:yes, ~c"", [~c"Macro", ~c"Map", ~c"MapSet", ~c"MatchError"]}
+    assert expand(runtime, ~c"Dic") == {:yes, ~c"t", []}
+    # FIXME: ExUnit is not available when the MIX_ENV is dev. Need to figure out a way to make it complete later
+    # assert expand(runtime, ~c"Ex") == {:yes, [], [~c"ExUnit", ~c"Exception"]}
+  end
+
+  @tag :pending
+  test "Elixir no completion for underscored functions with no doc", %{runtime: runtime} do
+    {:module, _, bytecode, _} =
+      defmodule Elixir.Sample do
+        @moduledoc false
+        def __foo__, do: 0
+        @doc "Bar doc"
+        def __bar__, do: 1
+      end
+
+    File.write!("Elixir.Sample.beam", bytecode)
+    assert {:docs_v1, _, _, _, _, _, _} = Code.fetch_docs(Sample)
+    assert expand(runtime, ~c"Sample._") == {:yes, ~c"_bar__", []}
+  after
+    File.rm("Elixir.Sample.beam")
+    :code.purge(Sample)
+    :code.delete(Sample)
+  end
+
+  test "Elixir no completion for default argument functions with doc set to false", %{runtime: runtime} do
+    {:yes, ~c"", available} = expand(runtime, ~c"String.")
+    refute Enum.member?(available, ~c"rjust/2")
+    assert Enum.member?(available, ~c"replace/3")
+
+    assert expand(runtime, ~c"String.r") == {:yes, ~c"e", []}
+
+    {:module, _, bytecode, _} =
+      defmodule Elixir.DefaultArgumentFunctions do
+        @moduledoc false
+        def foo(a \\ :a, b, c \\ :c), do: {a, b, c}
+
+        def _do_fizz(a \\ :a, b, c \\ :c), do: {a, b, c}
+
+        @doc false
+        def __fizz__(a \\ :a, b, c \\ :c), do: {a, b, c}
+
+        @doc "bar/0 doc"
+        def bar, do: :bar
+        @doc false
+        def bar(a \\ :a, b, c \\ :c, d \\ :d), do: {a, b, c, d}
+        @doc false
+        def bar(a, b, c, d, e), do: {a, b, c, d, e}
+
+        @doc false
+        def baz(a \\ :a), do: {a}
+
+        @doc "biz/3 doc"
+        def biz(a, b, c \\ :c), do: {a, b, c}
+      end
+
+    File.write!("Elixir.DefaultArgumentFunctions.beam", bytecode)
+    assert {:docs_v1, _, _, _, _, _, _} = Code.fetch_docs(DefaultArgumentFunctions)
+
+    functions_list = [~c"bar/0", ~c"biz/2", ~c"biz/3", ~c"foo/1", ~c"foo/2", ~c"foo/3"]
+    assert expand(runtime, ~c"DefaultArgumentFunctions.") == {:yes, ~c"", functions_list}
+
+    assert expand(runtime, ~c"DefaultArgumentFunctions.bi") == {:yes, ~c"z", []}
+
+    assert expand(runtime, ~c"DefaultArgumentFunctions.foo") ==
+             {:yes, ~c"", [~c"foo/1", ~c"foo/2", ~c"foo/3"]}
+  after
+    File.rm("Elixir.DefaultArgumentFunctions.beam")
+    :code.purge(DefaultArgumentFunctions)
+    :code.delete(DefaultArgumentFunctions)
+  end
+
+  test "Elixir no completion", %{runtime: runtime} do
+    assert expand(runtime, ~c".") == {:no, ~c"", []}
+    assert expand(runtime, ~c"Xyz") == {:no, ~c"", []}
+    assert expand(runtime, ~c"x.Foo") == {:no, ~c"", []}
+    assert expand(runtime, ~c"x.Foo.get_by") == {:no, ~c"", []}
+    assert expand(runtime, ~c"@foo.bar") == {:no, ~c"", []}
+  end
+
+  test "Elixir root submodule completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"Elixir.Acce") == {:yes, ~c"ss", []}
+  end
+
+  test "Elixir submodule completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"String.Cha") == {:yes, ~c"rs", []}
+  end
+
+  test "Elixir submodule no completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"IEx.Xyz") == {:no, ~c"", []}
+  end
+
+  test "function completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"System.ve") == {:yes, ~c"rsion", []}
+    assert expand(runtime, ~c":ets.fun2") == {:yes, ~c"ms", []}
+  end
+
+  test "function completion with arity", %{runtime: runtime} do
+    assert expand(runtime, ~c"String.printable?") == {:yes, ~c"", [~c"printable?/1", ~c"printable?/2"]}
+    assert expand(runtime, ~c"String.printable?/") == {:yes, ~c"", [~c"printable?/1", ~c"printable?/2"]}
+
+    assert expand(runtime, ~c"Enum.count") ==
+             {:yes, ~c"", [~c"count/1", ~c"count/2", ~c"count_until/2", ~c"count_until/3"]}
+
+    assert expand(runtime, ~c"Enum.count/") == {:yes, ~c"", [~c"count/1", ~c"count/2"]}
+  end
+
+  test "operator completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"+") == {:yes, ~c"", [~c"+/1", ~c"+/2", ~c"++/2"]}
+    assert expand(runtime, ~c"+/") == {:yes, ~c"", [~c"+/1", ~c"+/2"]}
+    assert expand(runtime, ~c"++/") == {:yes, ~c"", [~c"++/2"]}
+  end
+
+  test "sigil completion", %{runtime: runtime} do
+    {:yes, ~c"", sigils} = expand(runtime, ~c"~")
+    assert ~c"~C (sigil_C)" in sigils
+    {:yes, ~c"", sigils} = expand(runtime, ~c"~r")
+    assert ~c"\"" in sigils
+    assert ~c"(" in sigils
+  end
+
+  @tag :pending
+  test "map atom key completion is supported", %{runtime: runtime} do
+    prev = "map = %{foo: 1, bar_1: 23, bar_2: 14}"
+    assert expand(runtime, ~c"#{prev}\nmap.f") == {:yes, ~c"oo", []}
+    # assert expand(runtime, ~c"map.b") == {:yes, ~c"ar_", []}
+    # assert expand(runtime, ~c"map.bar_") == {:yes, ~c"", [~c"bar_1", ~c"bar_2"]}
+    # assert expand(runtime, ~c"map.c") == {:no, ~c"", []}
+    # assert expand(runtime, ~c"map.") == {:yes, ~c"", [~c"bar_1", ~c"bar_2", ~c"foo"]}
+    # assert expand(runtime, ~c"map.foo") == {:no, ~c"", []}
+  end
+
+  @tag :pending
+  test "nested map atom key completion is supported", %{runtime: runtime} do
+    prev = "map = %{nested: %{deeply: %{foo: 1, bar_1: 23, bar_2: 14, mod: String, num: 1}}}"
+    assert expand(runtime, ~c"map.nested.deeply.f") == {:yes, ~c"oo", []}
+    assert expand(runtime, ~c"map.nested.deeply.b") == {:yes, ~c"ar_", []}
+    assert expand(runtime, ~c"map.nested.deeply.bar_") == {:yes, ~c"", [~c"bar_1", ~c"bar_2"]}
+
+    assert expand(runtime, ~c"map.nested.deeply.") ==
+             {:yes, ~c"", [~c"bar_1", ~c"bar_2", ~c"foo", ~c"mod", ~c"num"]}
+
+    assert expand(runtime, ~c"map.nested.deeply.mod.print") == {:yes, ~c"able?", []}
+
+    assert expand(runtime, ~c"map.nested") == {:yes, ~c".", []}
+    assert expand(runtime, ~c"map.nested.deeply") == {:yes, ~c".", []}
+    assert expand(runtime, ~c"map.nested.deeply.foo") == {:no, ~c"", []}
+
+    assert expand(runtime, ~c"map.nested.deeply.c") == {:no, ~c"", []}
+    assert expand(runtime, ~c"map.a.b.c.f") == {:no, ~c"", []}
+  end
+
+  @tag :pending
+  test "map string key completion is not supported", %{runtime: runtime} do
+    prev = ~S(map = %{"foo" => 1})
+    assert expand(runtime, ~c"map.f") == {:no, ~c"", []}
+  end
+
+  @tag :pending
+  test "bound variables for modules and maps", %{runtime: runtime} do
+    prev = "num = 5; map = %{nested: %{num: 23}}"
+    assert expand(runtime, ~c"num.print") == {:no, ~c"", []}
+    assert expand(runtime, ~c"map.nested.num.f") == {:no, ~c"", []}
+    assert expand(runtime, ~c"map.nested.num.key.f") == {:no, ~c"", []}
+  end
+
+  @tag :pending
+  test "access syntax is not supported", %{runtime: runtime} do
+    prev = "map = %{nested: %{deeply: %{num: 23}}}"
+    assert expand(runtime, ~c"map[:nested][:deeply].n") == {:no, ~c"", []}
+    assert expand(runtime, ~c"map[:nested].deeply.n") == {:no, ~c"", []}
+    assert expand(runtime, ~c"map.nested.[:deeply].n") == {:no, ~c"", []}
+  end
+
+  @tag :pending
+  test "unbound variables is not supported", %{runtime: runtime} do
+    prev = "num = 5"
+
+    assert expand(runtime, dbg(~c"#{prev}\nother_var.f")) == {:no, ~c"", []}
+
+    # assert expand(runtime, ~c"a.b.c.d") == {:no, ~c"", []}
+  end
+
+  test "macro completion", %{runtime: runtime} do
+    {:yes, ~c"", list} = expand(runtime, ~c"Kernel.is_")
+    assert is_list(list)
+  end
+
+  test "imports completion", %{runtime: runtime} do
+    {:yes, ~c"", list} = expand(runtime, ~c"")
+    assert is_list(list)
+    assert ~c"h/1" in list
+    assert ~c"unquote/1" in list
+    assert ~c"pwd/0" in list
+  end
+
+  test "kernel import completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"defstru") == {:yes, ~c"ct", []}
+    assert expand(runtime, ~c"put_") == {:yes, ~c"", [~c"put_elem/3", ~c"put_in/2", ~c"put_in/3"]}
+  end
+
+  test "variable name completion", %{runtime: runtime} do
+    prev = "numeral = 3; number = 3; nothing = nil"
+    assert expand(runtime, dbg(~c"#{prev}\nnumb")) == {:yes, ~c"er", []}
+    assert expand(runtime, ~c"#{prev}\nnum") == {:yes, ~c"", [~c"number", ~c"numeral"]}
+    # FIXME: variables + local functions
+    # assert expand(runtime, ~c"#{prev}\nno") == {:yes, ~c"", [~c"nothing", ~c"node/0", ~c"node/1", ~c"not/1"]}
+  end
+
+  test "completion of manually imported functions and macros", %{runtime: runtime} do
+    prev = "import Enum\nimport Supervisor, only: [count_children: 1]\nimport Protocol"
+
+    assert expand(runtime, ~c"#{prev}\nder") == {:yes, ~c"ive", []}
+
+    assert expand(runtime, ~c"#{prev}\ntake") ==
+             {:yes, ~c"", [~c"take/2", ~c"take_every/2", ~c"take_random/2", ~c"take_while/2"]}
+
+    assert expand(runtime, ~c"#{prev}\ntake/") == {:yes, ~c"", [~c"take/2"]}
+
+    assert expand(runtime, ~c"#{prev}\ncount") ==
+             {:yes, ~c"",
+              [
+                ~c"count/1",
+                ~c"count/2",
+                ~c"count_children/1",
+                ~c"count_until/2",
+                ~c"count_until/3"
+              ]}
+
+    assert expand(runtime, ~c"#{prev}\ncount/") == {:yes, ~c"", [~c"count/1", ~c"count/2"]}
+  end
+
+  defmacro define_var do
+    quote(do: var!(my_var_1, Elixir) = 1)
+  end
+
+  test "ignores quoted variables when performing variable completion", %{runtime: runtime} do
+    prev = "require #{__MODULE__}; #{__MODULE__}.define_var(); my_var_2 = 2"
+    assert expand(runtime, ~c"my_var") == {:yes, ~c"_2", []}
+  end
+
+  test "kernel special form completion", %{runtime: runtime} do
+    assert expand(runtime, ~c"unquote_spl") == {:yes, ~c"icing", []}
+  end
+
+  test "completion inside expression", %{runtime: runtime} do
+    assert expand(runtime, ~c"1 En") == {:yes, ~c"um", []}
+    assert expand(runtime, ~c"Test(En") == {:yes, ~c"um", []}
+    assert expand(runtime, ~c"Test :zl") == {:yes, ~c"ib", []}
+    assert expand(runtime, ~c"[:zl") == {:yes, ~c"ib", []}
+    assert expand(runtime, ~c"{:zl") == {:yes, ~c"ib", []}
+  end
+
+  defmodule SublevelTest.LevelA.LevelB do
+    @moduledoc false
+  end
+
+  test "Elixir completion sublevel", %{runtime: runtime} do
+    assert expand(runtime, ~c"NextLS.AutocompleteTest.SublevelTest.") == {:yes, ~c"LevelA", []}
+  end
+
+  test "complete aliases of Elixir modules", %{runtime: runtime} do
+    prev = "alias List, as: MyList"
+    assert expand(runtime, ~c"MyL") == {:yes, ~c"ist", []}
+    assert expand(runtime, ~c"MyList") == {:yes, ~c".", []}
+    assert expand(runtime, ~c"MyList.to_integer") == {:yes, [], [~c"to_integer/1", ~c"to_integer/2"]}
+  end
+
+  test "complete aliases of Erlang modules", %{runtime: runtime} do
+    prev = "alias :lists, as: EList"
+    assert expand(runtime, ~c"#{prev}\nEL") == {:yes, ~c"ist", []}
+    assert expand(runtime, ~c"#{prev}\nEList") == {:yes, ~c".", []}
+    assert expand(runtime, ~c"#{prev}\nEList.map") == {:yes, [], [~c"map/2", ~c"mapfoldl/3", ~c"mapfoldr/3"]}
+  end
+
+  test "completion for functions added when compiled module is reloaded", %{runtime: runtime} do
+    {:module, _, bytecode, _} =
+      defmodule Sample do
+        @moduledoc false
+        def foo, do: 0
+      end
+
+    File.write!("Elixir.NextLS.AutocompleteTest.Sample.beam", bytecode)
+    assert {:docs_v1, _, _, _, _, _, _} = Code.fetch_docs(Sample)
+    assert expand(runtime, ~c"NextLS.AutocompleteTest.Sample.foo") == {:yes, ~c"", [~c"foo/0"]}
+
+    Code.compiler_options(ignore_module_conflict: true)
+
+    defmodule Sample do
+      @moduledoc false
+      def foo, do: 0
+      def foobar, do: 0
+    end
+
+    assert expand(runtime, ~c"NextLS.AutocompleteTest.Sample.foo") == {:yes, ~c"", [~c"foo/0", ~c"foobar/0"]}
+  after
+    File.rm("Elixir.NextLS.AutocompleteTest.Sample.beam")
+    Code.compiler_options(ignore_module_conflict: false)
+    :code.purge(Sample)
+    :code.delete(Sample)
+  end
+
+  defmodule MyStruct do
+    @moduledoc false
+    defstruct [:my_val]
+  end
+
+  test "completion for struct names", %{runtime: runtime} do
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%")
+    assert ~c"URI" in entries
+    assert ~c"IEx.History" in entries
+    assert ~c"IEx.Server" in entries
+
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%IEx.")
+    assert ~c"IEx.History" in entries
+    assert ~c"IEx.Server" in entries
+
+    assert expand(runtime, ~c"%IEx.AutocompleteTe") == {:yes, ~c"st.MyStruct{", []}
+    assert expand(runtime, ~c"%NextLS.AutocompleteTest.MyStr") == {:yes, ~c"uct{", []}
+
+    prev = "alias NextLS.AutocompleteTest.MyStruct"
+    assert expand(runtime, ~c"%MyStr") == {:yes, ~c"uct{", []}
+  end
+
+  test "completion for struct keys", %{runtime: runtime} do
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{")
+    assert ~c"path:" in entries
+    assert ~c"query:" in entries
+
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{path: \"foo\",")
+    assert ~c"path:" not in entries
+    assert ~c"query:" in entries
+
+    assert {:yes, ~c"ry: ", []} = expand(runtime, ~c"%URI{path: \"foo\", que")
+    assert {:no, [], []} = expand(runtime, ~c"%URI{path: \"foo\", unkno")
+    assert {:no, [], []} = expand(runtime, ~c"%Unkown{path: \"foo\", unkno")
+  end
+
+  test "completion for struct keys in update syntax", %{runtime: runtime} do
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{var | ")
+    assert ~c"path:" in entries
+    assert ~c"query:" in entries
+
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%URI{var | path: \"foo\",")
+    assert ~c"path:" not in entries
+    assert ~c"query:" in entries
+
+    assert {:yes, ~c"ry: ", []} = expand(runtime, ~c"%URI{var | path: \"foo\", que")
+    assert {:no, [], []} = expand(runtime, ~c"%URI{var | path: \"foo\", unkno")
+    assert {:no, [], []} = expand(runtime, ~c"%Unkown{var | path: \"foo\", unkno")
+  end
+
+  test "completion for map keys in update syntax", %{runtime: runtime} do
+    prev = "map = %{some: 1, other: :ok, another: \"qwe\"}"
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%{map | ")
+    assert ~c"some:" in entries
+    assert ~c"other:" in entries
+
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"%{map | some: \"foo\",")
+    assert ~c"some:" not in entries
+    assert ~c"other:" in entries
+
+    assert {:yes, ~c"er: ", []} = expand(runtime, ~c"%{map | some: \"foo\", oth")
+    assert {:no, [], []} = expand(runtime, ~c"%{map | some: \"foo\", unkno")
+    assert {:no, [], []} = expand(runtime, ~c"%{unknown | some: \"foo\", unkno")
+  end
+
+  test "completion for struct var keys", %{runtime: runtime} do
+    prev = "struct = %NextLS.AutocompleteTest.MyStruct{}"
+    assert expand(runtime, ~c"struct.my") == {:yes, ~c"_val", []}
+  end
+
+  test "completion for bitstring modifiers", %{runtime: runtime} do
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"<<foo::")
+    assert ~c"integer" in entries
+    assert ~c"size/1" in entries
+
+    assert {:yes, ~c"eger", []} = expand(runtime, ~c"<<foo::int")
+
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"<<foo::integer-")
+    refute ~c"integer" in entries
+    assert ~c"little" in entries
+    assert ~c"size/1" in entries
+
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"<<foo::integer-little-")
+    refute ~c"integer" in entries
+    refute ~c"little" in entries
+    assert ~c"size/1" in entries
+  end
+
+  test "completion for aliases in special forms", %{runtime: runtime} do
+    assert {:yes, ~c"", entries} = expand(runtime, ~c"alias ")
+    assert ~c"Atom" in entries
+    refute ~c"is_atom" in entries
+
+    assert {:yes, ~c"Range", []} = expand(runtime, ~c"alias Date.")
+  end
+
+  test "ignore invalid Elixir module literals", %{runtime: runtime} do
+    defmodule(:"Elixir.NextLS.AutocompleteTest.Unicodé", do: nil)
+    assert expand(runtime, ~c"NextLS.AutocompleteTest.Unicod") == {:no, ~c"", []}
+  after
+    :code.purge(:"Elixir.NextLS.AutocompleteTest.Unicodé")
+    :code.delete(:"Elixir.NextLS.AutocompleteTest.Unicodé")
+  end
+
+  test "signature help for functions and macros", %{runtime: runtime} do
+    assert expand(runtime, ~c"String.graphemes(") == {:yes, ~c"", [~c"graphemes(string)"]}
+    assert expand(runtime, ~c"def ") == {:yes, ~c"", [~c"def(call, expr \\\\ nil)"]}
+
+    prev = "import Enum; import Protocol"
+
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             send(self(), expand(runtime, ~c"reduce("))
+           end) == "\nreduce(enumerable, acc, fun)"
+
+    assert_received {:yes, ~c"", [~c"reduce(enumerable, fun)"]}
+
+    assert expand(runtime, ~c"take(") == {:yes, ~c"", [~c"take(enumerable, amount)"]}
+    assert expand(runtime, ~c"derive(") == {:yes, ~c"", [~c"derive(protocol, module, options \\\\ [])"]}
+
+    defmodule NoDocs do
+      @moduledoc false
+      def sample(a), do: a
+    end
+
+    assert {:yes, [], [_ | _]} = expand(runtime, ~c"NoDocs.sample(")
+  end
+
+  test "path completion inside strings", %{tmp_dir: dir, runtime: runtime} do
+    dir |> Path.join("single1") |> File.touch()
+    dir |> Path.join("file1") |> File.touch()
+    dir |> Path.join("file2") |> File.touch()
+    dir |> Path.join("dir") |> File.mkdir()
+    dir |> Path.join("dir/file3") |> File.touch()
+    dir |> Path.join("dir/file4") |> File.touch()
+
+    assert expand(runtime, ~c"\"./") == path_autocompletion(".")
+    assert expand(runtime, ~c"\"/") == path_autocompletion("/")
+    assert expand(runtime, ~c"\"./#\{") == expand(runtime, ~c"{")
+    assert expand(runtime, ~c"\"./#\{Str") == expand(runtime, ~c"{Str")
+    assert expand(runtime, ~c"Path.join(\"./\", is_") == expand(runtime, ~c"is_")
+
+    assert expand(runtime, ~c"\"#{dir}/") == path_autocompletion(dir)
+    assert expand(runtime, ~c"\"#{dir}/sin") == {:yes, ~c"gle1", []}
+    assert expand(runtime, ~c"\"#{dir}/single1") == {:yes, ~c"\"", []}
+    assert expand(runtime, ~c"\"#{dir}/fi") == {:yes, ~c"le", []}
+    assert expand(runtime, ~c"\"#{dir}/file") == path_autocompletion(dir, "file")
+    assert expand(runtime, ~c"\"#{dir}/d") == {:yes, ~c"ir/", []}
+    assert expand(runtime, ~c"\"#{dir}/dir") == {:yes, ~c"/", []}
+    assert expand(runtime, ~c"\"#{dir}/dir/") == {:yes, ~c"file", []}
+    assert expand(runtime, ~c"\"#{dir}/dir/file") == dir |> Path.join("dir") |> path_autocompletion("file")
+  end
+
+  defp path_autocompletion(dir, hint \\ "") do
+    dir
+    |> File.ls!()
+    |> Stream.filter(&String.starts_with?(&1, hint))
+    |> Enum.map(&String.to_charlist/1)
+    |> case do
+      [] -> {:no, ~c"", []}
+      list -> {:yes, ~c"", list}
+    end
+  end
+end

--- a/test/next_ls/autocomplete_test.exs
+++ b/test/next_ls/autocomplete_test.exs
@@ -648,8 +648,9 @@ defmodule NextLS.AutocompleteTest do
     assert expand(runtime, ~c"\"#{dir}/sin") == {:yes, [%{name: "single1", kind: :file}]}
     assert expand(runtime, ~c"\"#{dir}/single1") == {:yes, [%{name: "single1", kind: :file}]}
 
-    assert expand(runtime, ~c"\"#{dir}/fi") ==
-             {:yes, [%{name: "file2", kind: :file}, %{name: "file1", kind: :file}]}
+    assert {:yes, [_, _] = files} = expand(runtime, ~c"\"#{dir}/fi")
+    assert %{name: "file2", kind: :file} in files
+    assert %{name: "file1", kind: :file} in files
 
     assert expand(runtime, ~c"\"#{dir}/file") == path_autocompletion(dir, "file")
     assert expand(runtime, ~c"\"#{dir}/d") == {:yes, [%{name: "dir/", kind: :dir}]}

--- a/test/next_ls/completions_test.exs
+++ b/test/next_ls/completions_test.exs
@@ -356,21 +356,22 @@ defmodule NextLS.CompletionsTest do
       }
     }
 
-    assert_result 2, [
-      %{
-        "data" => nil,
-        "documentation" => "",
-        "insertText" => "next_ls.ex",
-        "kind" => 17,
-        "label" => "next_ls.ex"
-      },
-      %{
-        "data" => nil,
-        "documentation" => "",
-        "insertText" => "next_ls/",
-        "kind" => 19,
-        "label" => "next_ls/"
-      }
-    ]
+    assert_result 2, [_, _] = results
+
+    assert %{
+             "data" => nil,
+             "documentation" => "",
+             "insertText" => "next_ls.ex",
+             "kind" => 17,
+             "label" => "next_ls.ex"
+           } in results
+
+    assert %{
+             "data" => nil,
+             "documentation" => "",
+             "insertText" => "next_ls/",
+             "kind" => 19,
+             "label" => "next_ls/"
+           } in results
   end
 end

--- a/test/next_ls/completions_test.exs
+++ b/test/next_ls/completions_test.exs
@@ -1,0 +1,376 @@
+defmodule NextLS.CompletionsTest do
+  use ExUnit.Case, async: true
+
+  import GenLSP.Test
+  import NextLS.Support.Utils
+
+  @moduletag tmp_dir: true, root_paths: ["my_proj"]
+
+  setup %{tmp_dir: tmp_dir} do
+    File.mkdir_p!(Path.join(tmp_dir, "my_proj/lib"))
+    File.write!(Path.join(tmp_dir, "my_proj/mix.exs"), mix_exs())
+    cwd = tmp_dir
+
+    foo = Path.join(cwd, "my_proj/lib/foo.ex")
+
+    File.write!(foo, """
+    defmodule Foo do
+      def run() do
+
+        :ok
+      end
+    end
+    """)
+
+    [foo: foo, cwd: cwd]
+  end
+
+  setup :with_lsp
+
+  setup %{client: client} = context do
+    assert :ok == notify(client, %{method: "initialized", jsonrpc: "2.0", params: %{}})
+
+    assert_is_ready(context, "my_proj")
+    assert_notification "$/progress", %{"value" => %{"kind" => "end", "message" => "Finished indexing!"}}
+
+    :ok
+  end
+
+  test "global modules", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              En
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 6
+        }
+      }
+    }
+
+    assert_result 2, [
+      %{"data" => _, "documentation" => _, "insertText" => "Enum", "kind" => 9, "label" => "Enum"},
+      %{"data" => _, "documentation" => _, "insertText" => "Enumerable", "kind" => 9, "label" => "Enumerable"}
+    ]
+  end
+
+  test "global module remote functions", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              Enum.fl
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 11
+        }
+      }
+    }
+
+    assert_result 2, [
+      %{"data" => _, "documentation" => _, "insertText" => "flat_map", "kind" => 3, "label" => "flat_map/2"},
+      %{
+        "data" => _,
+        "documentation" => _,
+        "insertText" => "flat_map_reduce",
+        "kind" => 3,
+        "label" => "flat_map_reduce/3"
+      }
+    ]
+  end
+
+  test "global structs", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              %U
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 6
+        }
+      }
+    }
+
+    assert_result 2, [%{"data" => _, "documentation" => _, "insertText" => "URI", "kind" => 22, "label" => "URI"}]
+  end
+
+  test "structs fields", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              IO.inspect([%URI{])
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 21
+        }
+      }
+    }
+
+    assert_result 2, [
+      %{"data" => nil, "documentation" => "", "insertText" => "port", "kind" => 5, "label" => "port"},
+      %{"data" => nil, "documentation" => "", "insertText" => "scheme", "kind" => 5, "label" => "scheme"},
+      %{"data" => nil, "documentation" => "", "insertText" => "path", "kind" => 5, "label" => "path"},
+      %{"data" => nil, "documentation" => "", "insertText" => "host", "kind" => 5, "label" => "host"},
+      %{"data" => nil, "documentation" => "", "insertText" => "userinfo", "kind" => 5, "label" => "userinfo"},
+      %{"data" => nil, "documentation" => "", "insertText" => "fragment", "kind" => 5, "label" => "fragment"},
+      %{"data" => nil, "documentation" => "", "insertText" => "query", "kind" => 5, "label" => "query"},
+      %{"data" => nil, "documentation" => "", "insertText" => "authority", "kind" => 5, "label" => "authority"}
+    ]
+  end
+
+  test "special forms", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              qu
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 6
+        }
+      }
+    }
+
+    assert_result 2, [%{"data" => _, "documentation" => _, "insertText" => "quote", "kind" => 3, "label" => "quote/2"}]
+  end
+
+  test "bitstring modifiers", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              <<one::
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 11
+        }
+      }
+    }
+
+    assert_result 2, [
+      %{"data" => nil, "documentation" => "", "insertText" => "big", "kind" => 6, "label" => "big"},
+      %{"data" => nil, "documentation" => "", "insertText" => "binary", "kind" => 6, "label" => "binary"},
+      %{"data" => nil, "documentation" => "", "insertText" => "bitstring", "kind" => 6, "label" => "bitstring"},
+      %{"data" => nil, "documentation" => "", "insertText" => "integer", "kind" => 6, "label" => "integer"},
+      %{"data" => nil, "documentation" => "", "insertText" => "float", "kind" => 6, "label" => "float"},
+      %{"data" => nil, "documentation" => "", "insertText" => "little", "kind" => 6, "label" => "little"},
+      %{"data" => nil, "documentation" => "", "insertText" => "native", "kind" => 6, "label" => "native"},
+      %{"data" => nil, "documentation" => "", "insertText" => "signed", "kind" => 6, "label" => "signed"},
+      %{"data" => nil, "insertText" => "size", "kind" => 3, "label" => "size/1"},
+      %{"data" => nil, "insertText" => "unit", "kind" => 3, "label" => "unit/1"},
+      %{"data" => nil, "documentation" => "", "insertText" => "unsigned", "kind" => 6, "label" => "unsigned"},
+      %{"data" => nil, "documentation" => "", "insertText" => "utf8", "kind" => 6, "label" => "utf8"},
+      %{"data" => nil, "documentation" => "", "insertText" => "utf16", "kind" => 6, "label" => "utf16"},
+      %{"data" => nil, "documentation" => "", "insertText" => "utf32", "kind" => 6, "label" => "utf32"}
+    ]
+  end
+
+  test "file system paths in strings", %{client: client, foo: foo} do
+    uri = uri(foo)
+
+    notify client, %{
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri,
+          languageId: "elixir",
+          version: 1,
+          text: """
+          defmodule Foo do
+            def run() do
+              "./lib/
+              :ok
+            end
+          end
+          """
+        }
+      }
+    }
+
+    request client, %{
+      method: "textDocument/completion",
+      id: 2,
+      jsonrpc: "2.0",
+      params: %{
+        textDocument: %{
+          uri: uri
+        },
+        position: %{
+          line: 2,
+          character: 11
+        }
+      }
+    }
+
+    assert_result 2, [
+      %{
+        "data" => nil,
+        "documentation" => "",
+        "insertText" => "next_ls.ex",
+        "kind" => 17,
+        "label" => "next_ls.ex"
+      },
+      %{
+        "data" => nil,
+        "documentation" => "",
+        "insertText" => "next_ls/",
+        "kind" => 19,
+        "label" => "next_ls/"
+      }
+    ]
+  end
+end

--- a/test/next_ls/helpers/ast_helpers/variables_test.exs
+++ b/test/next_ls/helpers/ast_helpers/variables_test.exs
@@ -186,7 +186,7 @@ defmodule NextLS.ASTHelpers.VariablesTest do
       assert {:charlie, {7..7, 25..31}} in refs
     end
 
-    test "symbol set in a match and corrctly processing ^", %{source: source} do
+    test "symbol set in a match and correctly processing ^", %{source: source} do
       refs = Variables.list_variable_references(source, {5, 5})
       assert length(refs) == 2
       assert {:charlie, {6..6, 17..23}} in refs


### PR DESCRIPTION
## Description

Implements basic autocompletion.

Current completion candidates supported

- Global modules
- Global Structs
- Struct fields
- Remote functions (w/ documentation)
- Special Forms
- Bitstring modifiers
- filesystem paths in strings

More features, particularly features that rely on contextual information about the code itself (meaning, which identifiers, aliases, imports are available) will come in subsequent patches.

Partially addresses #45 

## Experimental

This patch also introduces a new initialization option, `experimental`.

This feature will be gated as an experimental feature as it's built out. The purpose of this is so that early-early adopters can try it out and report bugs, but folks who would rather wait for something more stable won't have it affect their workflows.

To enable this feature, toggle the completions experiment in your editor.

### Nvim (elixir-tools.nvim)

```lua
require("elixir").setup({
    nextls = {
        enable = true,
        init_options = {
            experimental = {
                completions = {
                    enable = true
                }
            }
        }
    },
    elixirls = {enable = false}
})
```

### Visual Studio Code (elixir-tools.vscode)

```json
{
  "elixir-tools.nextLS.experimental.completions.enable": true
}
```

### Other editors

Not sure 😅

## Demos

TODO: record them my guy

## TODO

- [x] integration tests
- [ ] update elixir-tools.dev with instructions
- [x] update README with instructions

## Acknowedgements

This feature is initially based on `IEx.Autocomplete`. Huge thanks to the Elixir core team's efforts to help kickstart this feature. More deviations will likely occur as we gain more contextual parsing for things like imports, aliases and variables.
