### PR TITLE
Cleanup same file occurrences when inserting a symbol

### DIFF
--- a/lib/next_ls/db.ex
+++ b/lib/next_ls/db.ex
@@ -85,9 +85,9 @@ defmodule NextLS.DB do
       {conn, s.logger},
       ~Q"""
       DELETE FROM symbols
-      WHERE module = ?;
+      WHERE module = ? OR file = ?;
       """,
-      [mod]
+      [mod, file]
     )
 
     __query__(


### PR DESCRIPTION
This pull request ensures that when inserting a symbol we clean up the existing symbols for the same file.

Previously we were just removing the existing symbols for the same module, which worked if we update a module or rename its file. This left one corner case uncovered: renaming the module while keeping the filename.

This pull request fixes this and should fix #305. To test this you can perform the steps that I wrote in there and confirm that after renaming the module, the old module information is not present anymore in the `symbols` table.

