### PR TITLE
ci: add cachix-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,4 +140,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: nixbuild/nix-quick-install-action@v26
+      - uses: cachix/cachix-action@v12
+        with:
+          name: YOUR_CACHIX_ACCOUNT
+          signingKey: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,9 +139,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: nixbuild/nix-quick-install-action@v26
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v12
         with:
-          name: YOUR_CACHIX_ACCOUNT
-          signingKey: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          name: elixir-tools
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,10 +139,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v22
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: cachix/cachix-action@v12
         with:
           name: elixir-tools
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build
+      - run: nix flake check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,5 +146,5 @@ jobs:
         with:
           name: elixir-tools
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix build
-      - run: nix flake check
+      - run: nix build --accept-flake-config
+      - run: nix flake check --accept-flake-config

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   inputs = {nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";};
 
   nixConfig = {
-    extra-substituters = [ "https://YOUR_CACHIX_ACCOUNT.cachix.org" ];
-    extra-trusted-public-keys = [ "YOUR_CACHIX_PUBLIC_KEY" ];
+    extra-substituters = [ "https://elixir-tools.cachix.org" ];
+    extra-trusted-public-keys = [ "elixir-tools.cachix.org-1:GfK9E139Ysi+YWeS1oNN9OaTfQjqpLwlBaz+/73tBjU=" ];
   };
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   inputs = {nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";};
 
+  nixConfig = {
+    extra-substituters = [ "https://YOUR_CACHIX_ACCOUNT.cachix.org" ];
+    extra-trusted-public-keys = [ "YOUR_CACHIX_PUBLIC_KEY" ];
+  };
+
   outputs = {
     self,
     nixpkgs,


### PR DESCRIPTION
This PR is a follow up to #312 and is intended to:

- Save time on CI
- Make the binaries immediately available to Nix users

 by pushing newly built Nix assets to your cachix account.

As extra steps, you will have to:

- [x] Replace `YOUR_CACHIX_ACCOUNT` with the name of your cachix account.
- [x] Replace `YOUR_CACHIX_PUBLIC_KEY` which you can find at https://app.cachix.org/cache/YOUR_CACHIX_ACCOUNT
- [x] Generate a per-cache **write** auth token from https://app.cachix.org/cache/YOUR_CACHIX_ACCOUNT/settings/authtokens and add it as `CACHIX_AUTH_TOKEN` to the secrets of your repository (or even the organization).