### PR TITLE
refactor: reduce imperative shell logic in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,16 +58,11 @@
             hash = "sha256-LV1DYmWi0Mcz1S5k77/jexXYqay7OpysCwOtUcafqGE=";
           };
 
-          preConfigure = ''
-            export HOME="$(pwd)"
-          '';
+          BURRITO_ERTS_PATH = "${beamPackages.erlang}/lib/erlang";
+          BURRITO_TARGET = lib.optional localBuild burritoExe.${system};
 
           preBuild = ''
-            export BURRITO_ERTS_PATH=${beamPackages.erlang}/lib/erlang
-          '';
-
-          preInstall = lib.optionalString localBuild ''
-            export BURRITO_TARGET="${burritoExe.${system}}"
+            export HOME="$tmpDir"
           '';
 
           postInstall = ''

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,15 @@
       system,
       beamPackages,
       elixir,
-    }: rec {
+    }: let
+      aliased_7zz = pkgs.symlinkJoin {
+        name = "7zz-aliased";
+        paths = [pkgs._7zz];
+        postBuild = ''
+          ln -s ${pkgs._7zz}/bin/7zz $out/bin/7z
+        '';
+      };
+    in rec {
       default = lib.makeOverridable ({
         localBuild,
         beamPackages,
@@ -42,7 +50,7 @@
           inherit (beamPackages) erlang;
           inherit elixir;
 
-          nativeBuildInputs = [pkgs.xz pkgs.zig_0_11 pkgs._7zz];
+          nativeBuildInputs = [pkgs.xz pkgs.zig_0_11 aliased_7zz];
 
           mixFodDeps = beamPackages.fetchMixDeps {
             inherit src version elixir;
@@ -51,14 +59,7 @@
           };
 
           preConfigure = ''
-            bindir="$(pwd)/bin"
-            mkdir -p "$bindir"
-            echo '#!/usr/bin/env bash
-            7zz "$@"' > "$bindir/7z"
-            chmod +x "$bindir/7z"
-
             export HOME="$(pwd)"
-            export PATH="$bindir:$PATH"
           '';
 
           preBuild = ''


### PR DESCRIPTION
Regarding `HOME` specifically, I would've liked to eliminate that too as it's nearly always a pungent smell in Nix builds, but [Burrito.Steps.Build.PackAndBuild](https://github.com/burrito-elixir/burrito/blob/a60c6ab21156fc4c788907d33bfd0c546a022272/lib/steps/build/pack_and_build.ex#L26-L38) seems to
want a writable path to work in. AFAICT it's purely for scratch space, so we can just directly reuse the Nix build's temporary directory.