### PR TITLE
ci: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      timezone: UTC
+      interval: weekly
+      time: "11:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
An older version of `actions/checkout` is used in one of your GitHub workflows. This PR sets up Dependabot which will notify you updates on used actions in the form of pull requests.