### PR TITLE
ci: add workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: main
+  workflow_dispatch:
 
 jobs:
   commitlint:


### PR DESCRIPTION
My PRs (#325 and #326) failed in "Lint PR Title" step (added in #324) of the CI. I fixed those PR titles, but the statuses are not updated.

This PR adds a button like below, which you can use to manually dispatch the workflow without pushing a new commit to the branch.

![wayshot-20231103-170933](https://github.com/elixir-tools/next-ls/assets/6270544/ca977dc3-c73a-44b9-b8c2-8a94c9cfa76d)
