### PR TITLE
fix: vscode sends an another "attribute"

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -369,7 +369,7 @@ defmodule NextLS do
                       nil
                   end
 
-                nil ->
+                _ ->
                   nil
               end
             else


### PR DESCRIPTION
This fixes a no case clause matching "attribute" exception seen in VSCode.