### PR TITLE
feat: spike enabling test diagnostics

### DIFF
--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -250,7 +250,7 @@ defmodule NextLS.Runtime do
           File.rm_rf!(Path.join(state.working_dir, ".elixir-tools/_build"))
         end
 
-        case :rpc.call(node, :_next_ls_private_compiler, :compile, []) do
+        case :rpc.call(node, :_next_ls_private_compiler, :compile, [:test]) do
           {:badrpc, error} ->
             NextLS.Logger.error(state.logger, "Bad RPC call to node #{node}: #{inspect(error)}")
             []

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -225,7 +225,7 @@ defmodule :_next_ls_private_compiler do
 
   @tracers Code.get_compiler_option(:tracers)
 
-  def compile do
+  def compile(mix_env) do
     # keep stdout on this node
     Process.group_leader(self(), Process.whereis(:user))
     Code.put_compiler_option(:parser_options, columns: true, token_metadata: true)
@@ -245,12 +245,73 @@ defmodule :_next_ls_private_compiler do
 
     Code.put_compiler_option(:tracers, [NextLSPrivate.Tracer | @tracers])
 
-    Mix.Task.rerun("compile", [
-      "--ignore-module-conflict",
-      "--no-protocol-consolidation",
-      "--return-errors"
-    ])
+    # Load ExUnit before we compile anything in case we are compiling
+    # helper modules that depend on ExUnit.
+    if mix_env == :test, do: Application.ensure_loaded(:ex_unit)
+
+    # TODO: Refactor to not be conditional soup
+    case Mix.Task.rerun("compile", [
+           "--ignore-module-conflict",
+           "--no-protocol-consolidation",
+           "--return-errors"
+         ]) do
+      {:error, diagnostics} ->
+        {:error, diagnostics}
+
+      {:noop, diagnostics} ->
+        if mix_env == :test do
+          case IO.inspect(require_all_tests()) do
+            # TODO: Figure out what to do with warnings
+            {:ok, _modules, warnings} -> {:ok, diagnostics}
+            {:error, test_diagnostics, warnings} -> 
+                {:error, Enum.into(test_diagnostics, diagnostics, & struct(Mix.Task.Compiler.Diagnostic, &1))}
+          end
+        else
+          {:ok, diagnostics}
+        end
+    end
   rescue
     e -> {:error, e}
+  end
+
+  # Assumes code has already been compiled and :ex_unit has been loaded
+  def require_all_tests do
+    project = Mix.Project.config()
+    test_paths = project[:test_paths] || default_test_paths()
+    Enum.each(test_paths, &require_test_helper/1)
+
+    # Finally parse, require and load the files
+    test_pattern = project[:test_pattern] || "*_test.exs"
+    # warn_test_pattern = project[:warn_test_pattern] || "*_test.ex"
+
+    matched_test_files = Mix.Utils.extract_files(test_paths, test_pattern)
+    # TODO: Maybe warn if a file matches warn_test_pattern
+
+    Kernel.ParallelCompiler.require(matched_test_files, return_diagnostics: true)
+  rescue
+    e -> {:error, e}
+  end
+
+  defp relative_app_file_exists?(file) do
+    {file, _} = ExUnit.Filters.parse_path(file)
+    File.exists?(Path.join("../..", file))
+  end
+
+  defp require_test_helper(dir) do
+    file = Path.join(dir, "test_helper.exs")
+
+    if File.exists?(file) do
+      Code.require_file(file)
+    else
+      raise "Cannot run tests because test helper file #{inspect(file)} does not exist"
+    end
+  end
+
+  defp default_test_paths do
+    if File.dir?("test") do
+      ["test"]
+    else
+      []
+    end
   end
 end


### PR DESCRIPTION
To get this working initially, hard-codes compiles to run with `mix_env == :test`.