### PR TITLE
chore(nix): use beam_minimal to remove xwidgets dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     forAllSystems = f:
       nixpkgs.lib.genAttrs (builtins.attrNames burritoExe) (system: let
         pkgs = nixpkgs.legacyPackages.${system};
-        beamPackages = pkgs.beam.packages.erlang_26;
+        beamPackages = pkgs.beam_minimal.packages.erlang_26;
         elixir = beamPackages.elixir_1_15;
       in
         f {inherit system pkgs beamPackages elixir;});


### PR DESCRIPTION
By default, the BEAM package set on Nix depends on xwidgets, but this would be unnecessary for this language server. Nixpkgs provides [multiple variants of BEAM](https://github.com/NixOS/nixpkgs/blob/110f464d081a7f3cda85c5068f959814dd358958/pkgs/top-level/all-packages.nix#L17577-L17583):

```nix
  beam = callPackage ./beam-packages.nix { };
  beam_nox = callPackage ./beam-packages.nix { beam = beam_nox; wxSupport = false; };
  beam_minimal = callPackage ./beam-packages.nix {
    beam = beam_minimal;
    wxSupport = false;
    systemdSupport = false;
  };
```

The minimal version would be sufficient for this project. With this change, downloading time of the Nix package will be reduced.