### PR TITLE
feat(runtime): support workspace shims with `elixir_exec` option

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -661,6 +661,7 @@ defmodule NextLS do
              uri: uri,
              mix_env: lsp.assigns.init_opts.mix_env,
              mix_target: lsp.assigns.init_opts.mix_target,
+             elixir_exec: lsp.assigns.init_opts.elixir_exec,
              on_initialized: fn status ->
                if status == :ready do
                  Progress.stop(lsp, token, "NextLS runtime for folder #{name} has initialized!")
@@ -1117,6 +1118,7 @@ defmodule NextLS do
 
     defstruct mix_target: "host",
               mix_env: "dev",
+              elixir_exec: nil,
               experimental: %NextLS.InitOpts.Experimental{},
               extensions: %NextLS.InitOpts.Extensions{}
 
@@ -1126,6 +1128,7 @@ defmodule NextLS do
           schema(__MODULE__, %{
             optional(:mix_target) => str(),
             optional(:mix_env) => str(),
+            optional(:elixir_exec) => str(),
             optional(:experimental) =>
               schema(NextLS.InitOpts.Experimental, %{
                 optional(:completions) =>

--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -111,7 +111,7 @@ defmodule NextLS.Runtime do
     new_path = String.replace(path, bindir <> ":", "")
 
     with dir when is_list(dir) <- :code.priv_dir(:next_ls),
-         elixir_exe when is_binary(elixir_exe) <- System.find_executable("elixir") do
+         elixir_exe when is_binary(elixir_exe) <- use_or_find_elixir_exec(opts) do
       exe =
         dir
         |> Path.join("cmd")
@@ -346,6 +346,18 @@ defmodule NextLS.Runtime do
       connect(node, port, attempts - 1)
     else
       true
+    end
+  end
+
+  defp use_or_find_elixir_exec(opts) do
+    with path when is_binary(path) <- opts[:elixir_exec],
+         exec = Path.expand(path),
+         true <- File.exists?(exec),
+         {_, 0} <- System.cmd(exec, ["--version"]) do
+      exec
+    else
+      _ ->
+        System.find_executable("elixir")
     end
   end
 end


### PR DESCRIPTION
Relates to #334

IDEs like to work with shims rather than tools that alter path (such as `mise`/`rtx`). As a result, one must launch their IDE manually from a terminal session with all the `PATH` loaded in order to properly find the `elixir` executable. This works fine, but switching between projects/workspaces that have varying Elixir/OTP versions will most likely be using the version loaded when launching the program from terminal.

One resolve might be to include shims in the `PATH` globally. However, that negates some of the reasoning to move to alternate tools like `mise.

Instead, this allows setting the `elixir_exec` option to point directly at a shim. When used in workspace directories, that should also be able to load the correct versions defined in the tool version files. This also allows keeping the need for a shim isolated to the LS tool rather than global use