### PR TITLE
Minimally support dl tag for Erlang hover docs

### DIFF
--- a/lib/next_ls/helpers/hover_helpers.ex
+++ b/lib/next_ls/helpers/hover_helpers.ex
@@ -50,6 +50,18 @@ defmodule NextLS.HoverHelpers do
     "_#{IO.iodata_to_binary(bins)}_" <> to_markdown(type, rest)
   end
 
+  def to_markdown("application/erlang+html" = type, [{:dl, _, lis} | rest]) do
+    "#{to_markdown(type, lis)}\n" <> to_markdown(type, rest)
+  end
+
+  def to_markdown("application/erlang+html" = type, [{:dt, _, children} | rest]) do
+    "* #{to_markdown(type, children)}\n" <> to_markdown(type, rest)
+  end
+
+  def to_markdown("application/erlang+html" = type, [{:dd, _, children} | rest]) do
+    "#{to_markdown(type, children)}\n" <> to_markdown(type, rest)
+  end
+
   def to_markdown("application/erlang+html", []) do
     ""
   end

--- a/test/next_ls/helpers/hover_helpers_test.exs
+++ b/test/next_ls/helpers/hover_helpers_test.exs
@@ -200,5 +200,65 @@ defmodule NextLS.HoverHelpersTest do
                * Repeat until there is no path between `V1` and `V2`.
                """)
     end
+
+    test "dl, dt, and dd" do
+      html = [
+        {:dl, [],
+         [
+           {:dt, [], [{:code, [], ["root"]}]},
+           {:dd, [],
+            [
+              {:p, [], ["The installation directory of Erlang/OTP, ", {:code, [], ["$ROOT"]}, ":"]},
+              {:pre, [],
+               [
+                 {:code, [],
+                  ["2> init:get_argument(root).\n{ok,[[\"/usr/local/otp/releases/otp_beam_solaris8_r10b_patched\"]]}"]}
+               ]}
+            ]},
+           {:dt, [], [{:code, [], ["progname"]}]},
+           {:dd, [],
+            [
+              {:p, [], ["The name of the program which started Erlang:"]},
+              {:pre, [], [{:code, [], ["3> init:get_argument(progname).\n{ok,[[\"erl\"]]}"]}]}
+            ]},
+           {:dt, [], [{:a, [id: "home"], []}, {:code, [], ["home"]}]},
+           {:dd, [],
+            [
+              {:p, [], ["The home directory (on Unix, the value of $HOME):"]},
+              {:pre, [], [{:code, [], ["4> init:get_argument(home).\n{ok,[[\"/home/harry\"]]}"]}]}
+            ]}
+         ]},
+        {:p, [], ["Returns ", {:code, [], ["error"]}, " if no value is associated with ", {:code, [], ["Flag"]}, "."]}
+      ]
+
+      actual = HoverHelpers.to_markdown("application/erlang+html", html)
+
+      assert String.trim(actual) ==
+               String.trim("""
+               * `root`
+               The installation directory of Erlang/OTP, `$ROOT`:
+
+               ```erlang
+               2> init:get_argument(root).
+               {ok,[[\"/usr/local/otp/releases/otp_beam_solaris8_r10b_patched\"]]}
+               ```
+               * `progname`
+               The name of the program which started Erlang:
+
+               ```erlang
+               3> init:get_argument(progname).
+               {ok,[[\"erl\"]]}
+               ```
+               * []()`home`
+               The home directory (on Unix, the value of $HOME):
+
+               ```erlang
+               4> init:get_argument(home).
+               {ok,[[\"/home/harry\"]]}
+               ```
+
+               Returns `error` if no value is associated with `Flag`.
+               """)
+    end
   end
 end


### PR DESCRIPTION
This handles the conversion of the description list tag to Markdown.
Markdown doesn't support what can be done with the dl tag, but this
renders something legible for the few cases it's used.

Here's how it looks for `:init.get_argument/1`:

<img width="496" alt="image" src="https://github.com/elixir-tools/next-ls/assets/64669/523df9fb-51de-4e9b-893a-95c570221ba7">

Fixes #361
