### PR TITLE
feat: add require code action

### DIFF
--- a/lib/next_ls/extensions/elixir_extension.ex
+++ b/lib/next_ls/extensions/elixir_extension.ex
@@ -114,12 +114,16 @@ defmodule NextLS.ElixirExtension do
   def clamp(line), do: max(line, 0)
 
   @unused_variable ~r/variable\s\"[^\"]+\"\sis\sunused/
+  @require_module ~r/you\smust\srequire/
   defp metadata(diagnostic) do
     base = %{"namespace" => "elixir"}
 
     cond do
       is_binary(diagnostic.message) and diagnostic.message =~ @unused_variable ->
         Map.put(base, "type", "unused_variable")
+
+      is_binary(diagnostic.message) and diagnostic.message =~ @require_module ->
+        Map.put(base, "type", "require")
 
       true ->
         base

--- a/lib/next_ls/extensions/elixir_extension/code_action.ex
+++ b/lib/next_ls/extensions/elixir_extension/code_action.ex
@@ -4,6 +4,7 @@ defmodule NextLS.ElixirExtension.CodeAction do
   @behaviour NextLS.CodeActionable
 
   alias NextLS.CodeActionable.Data
+  alias NextLS.ElixirExtension.CodeAction.Require
   alias NextLS.ElixirExtension.CodeAction.UnusedVariable
 
   @impl true
@@ -11,6 +12,9 @@ defmodule NextLS.ElixirExtension.CodeAction do
     case data.diagnostic.data do
       %{"type" => "unused_variable"} ->
         UnusedVariable.new(data.diagnostic, data.document, data.uri)
+
+      %{"type" => "require"} ->
+        Require.new(data.diagnostic, data.document, data.uri)
 
       _ ->
         []

--- a/lib/next_ls/extensions/elixir_extension/code_action/require.ex
+++ b/lib/next_ls/extensions/elixir_extension/code_action/require.ex
@@ -10,7 +10,7 @@ defmodule NextLS.ElixirExtension.CodeAction.Require do
 
   @one_indentation_level "  "
   @spec new(diagnostic :: Diagnostic.t(), [text :: String.t()], uri :: String.t()) :: [CodeAction.t()]
-  def new(diagnostic = %Diagnostic{}, text, uri) do
+  def new(%Diagnostic{} = diagnostic, text, uri) do
     range = diagnostic.range
 
     with {:ok, require_module} <- get_edit(diagnostic.message),

--- a/lib/next_ls/extensions/elixir_extension/code_action/require.ex
+++ b/lib/next_ls/extensions/elixir_extension/code_action/require.ex
@@ -1,0 +1,132 @@
+defmodule NextLS.ElixirExtension.CodeAction.Require do
+  @moduledoc false
+
+  alias GenLSP.Structures.CodeAction
+  alias GenLSP.Structures.Diagnostic
+  alias GenLSP.Structures.Position
+  alias GenLSP.Structures.Range
+  alias GenLSP.Structures.TextEdit
+  alias GenLSP.Structures.WorkspaceEdit
+
+  @one_indentation_level "  "
+  def new(%Diagnostic{} = diagnostic, text, uri) do
+    range = diagnostic.range
+
+    with {:ok, require_module} <- get_edit(diagnostic.message),
+         {:ok, ast} <- parse_ast(text),
+         {:ok, defm} <- nearest_defmodule(ast, range),
+         {:ok, indentation} <- get_indent(text, defm),
+         {:ok, module_name} <- get_module_name(defm),
+         nearest <- find_nearest_node_for_require(defm),
+         range <- get_edit_range(nearest) do
+      [
+        %CodeAction{
+          title: "Add missing require in #{module_name}",
+          diagnostics: [diagnostic],
+          edit: %WorkspaceEdit{
+            changes: %{
+              uri => [
+                %TextEdit{
+                  new_text: indentation <> require_module,
+                  range: range
+                }
+              ]
+            }
+          }
+        }
+      ]
+    else
+      _error ->
+        []
+    end
+  end
+
+  defp parse_ast(text) do
+    text
+    |> Enum.join("\n")
+    |> Spitfire.parse()
+  end
+
+  defp nearest_defmodule(ast, range) do
+    defmodules =
+      ast
+      |> Macro.prewalker()
+      |> Enum.filter(fn
+        {:defmodule, _, _} -> true
+        _ -> false
+      end)
+
+    if defmodules != [] do
+      defm =
+        Enum.min_by(defmodules, fn {_, ctx, _} ->
+          range.start.character - ctx[:line] + 1
+        end)
+
+      {:ok, defm}
+    else
+      {:error, "no defmodule definition"}
+    end
+  end
+
+  @module_name ~r/require\s+([^\s]+)\s+before/
+  defp get_edit(message) do
+    case Regex.run(@module_name, message) do
+      [_, module] -> {:ok, "require #{module}\n"}
+      _ -> {:error, "unable to find require"}
+    end
+  end
+
+  # Context starts from 1 while LSP starts from 0
+  # which works for us since we want to insert the require on the next line 
+  defp get_edit_range(context) do
+    %Range{
+      start: %Position{line: context[:line], character: 0},
+      end: %Position{line: context[:line], character: 0}
+    }
+  end
+
+  defp get_indent(text, {_, defm_context, _}) do
+    line = defm_context[:line] - 1
+
+    indent =
+      text
+      |> Enum.at(line)
+      |> then(&Regex.run(~r/^(\s*).*/, &1))
+      |> List.last()
+
+    {:ok, indent <> @one_indentation_level}
+  end
+
+  @top_level_macros [:import, :alias, :require]
+  defp find_nearest_node_for_require({:defmodule, context, _} = ast) do
+    top_level_macros =
+      ast
+      |> Macro.prewalker()
+      |> Enum.filter(fn
+        {:@, _, [{:moduledoc, _, _}]} -> true
+        {macro, _, _} when macro in @top_level_macros -> true
+        _ -> false
+      end)
+
+    case top_level_macros do
+      [] ->
+        context
+
+      _ ->
+        {_, context, _} = Enum.max_by(top_level_macros, fn {_, ctx, _} -> ctx[:line] end)
+        context
+    end
+  end
+
+  defp get_module_name({:defmodule, _, [{:__aliases__, _, alias} | _rest]}) do
+    name =
+      alias
+      |> Module.concat()
+      |> to_string()
+      |> String.replace_prefix("Elixir.", "")
+
+    {:ok, name}
+  end
+
+  defp get_module_name(_), do: {:error, "expected defmodule ast"}
+end

--- a/lib/next_ls/extensions/elixir_extension/code_action/require.ex
+++ b/lib/next_ls/extensions/elixir_extension/code_action/require.ex
@@ -124,8 +124,7 @@ defmodule NextLS.ElixirExtension.CodeAction.Require do
     name =
       alias
       |> Module.concat()
-      |> to_string()
-      |> String.replace_prefix("Elixir.", "")
+      |> Macro.to_string()
 
     {:ok, name}
   end

--- a/test/next_ls/extensions/elixir_extension/code_action/require_test.exs
+++ b/test/next_ls/extensions/elixir_extension/code_action/require_test.exs
@@ -38,7 +38,7 @@ defmodule NextLS.ElixirExtension.RequireTest do
     assert [code_action] = Require.new(diagnostic, text, uri)
     assert is_struct(code_action, CodeAction)
     assert [diagnostic] == code_action.diagnostics
-    assert code_action.title =~ "Test.Require"
+    assert code_action.title == "Add missing require for Logger"
 
     assert %WorkspaceEdit{
              changes: %{
@@ -83,7 +83,7 @@ defmodule NextLS.ElixirExtension.RequireTest do
     assert [code_action] = Require.new(diagnostic, text, uri)
     assert is_struct(code_action, CodeAction)
     assert [diagnostic] == code_action.diagnostics
-    assert code_action.title =~ "Test.Require"
+    assert code_action.title == "Add missing require for Logger"
 
     assert %WorkspaceEdit{
              changes: %{
@@ -130,7 +130,7 @@ defmodule NextLS.ElixirExtension.RequireTest do
     assert [code_action] = Require.new(diagnostic, text, uri)
     assert is_struct(code_action, CodeAction)
     assert [diagnostic] == code_action.diagnostics
-    assert code_action.title =~ "Test.Require"
+    assert code_action.title == "Add missing require for Logger"
 
     assert %WorkspaceEdit{
              changes: %{
@@ -186,7 +186,7 @@ defmodule NextLS.ElixirExtension.RequireTest do
     assert [code_action] = Require.new(diagnostic, text, uri)
     assert is_struct(code_action, CodeAction)
     assert [diagnostic] == code_action.diagnostics
-    assert code_action.title =~ "Require"
+    assert code_action.title == "Add missing require for Logger"
 
     assert %WorkspaceEdit{
              changes: %{

--- a/test/next_ls/extensions/elixir_extension/code_action/require_test.exs
+++ b/test/next_ls/extensions/elixir_extension/code_action/require_test.exs
@@ -1,0 +1,202 @@
+defmodule NextLS.ElixirExtension.RequireTest do
+  use ExUnit.Case, async: true
+
+  alias GenLSP.Structures.CodeAction
+  alias GenLSP.Structures.Position
+  alias GenLSP.Structures.Range
+  alias GenLSP.Structures.TextEdit
+  alias GenLSP.Structures.WorkspaceEdit
+  alias NextLS.ElixirExtension.CodeAction.Require
+
+  test "adds require to module" do
+    text =
+      String.split(
+        """
+        defmodule Test.Require do
+          def hello() do
+            Logger.info("foo")
+          end
+        end
+        """,
+        "\n"
+      )
+
+    start = %Position{character: 0, line: 1}
+
+    diagnostic = %GenLSP.Structures.Diagnostic{
+      data: %{"namespace" => "elixir", "type" => "require"},
+      message: "you must require Logger before invoking the macro Logger.info/1",
+      source: "Elixir",
+      range: %GenLSP.Structures.Range{
+        start: start,
+        end: %{start | character: 999}
+      }
+    }
+
+    uri = "file:///home/owner/my_project/hello.ex"
+
+    assert [code_action] = Require.new(diagnostic, text, uri)
+    assert is_struct(code_action, CodeAction)
+    assert [diagnostic] == code_action.diagnostics
+    assert code_action.title =~ "Test.Require"
+
+    assert %WorkspaceEdit{
+             changes: %{
+               ^uri => [
+                 %TextEdit{
+                   new_text: "  require Logger\n",
+                   range: %Range{start: ^start, end: ^start}
+                 }
+               ]
+             }
+           } = code_action.edit
+  end
+
+  test "adds require after moduledoc" do
+    text =
+      String.split(
+        """
+        defmodule Test.Require do
+          @moduledoc
+          def hello() do
+            Logger.info("foo")
+          end
+        end
+        """,
+        "\n"
+      )
+
+    start = %Position{character: 0, line: 2}
+
+    diagnostic = %GenLSP.Structures.Diagnostic{
+      data: %{"namespace" => "elixir", "type" => "require"},
+      message: "you must require Logger before invoking the macro Logger.info/1",
+      source: "Elixir",
+      range: %GenLSP.Structures.Range{
+        start: start,
+        end: %{start | character: 999}
+      }
+    }
+
+    uri = "file:///home/owner/my_project/hello.ex"
+
+    assert [code_action] = Require.new(diagnostic, text, uri)
+    assert is_struct(code_action, CodeAction)
+    assert [diagnostic] == code_action.diagnostics
+    assert code_action.title =~ "Test.Require"
+
+    assert %WorkspaceEdit{
+             changes: %{
+               ^uri => [
+                 %TextEdit{
+                   new_text: "  require Logger\n",
+                   range: %Range{start: ^start, end: ^start}
+                 }
+               ]
+             }
+           } = code_action.edit
+  end
+
+  test "adds require after alias" do
+    text =
+      String.split(
+        """
+        defmodule Test.Require do
+          @moduledoc
+          import Test.Foo
+          alias Test.Bar
+          def hello() do
+            Logger.info("foo")
+          end
+        end
+        """,
+        "\n"
+      )
+
+    start = %Position{character: 0, line: 4}
+
+    diagnostic = %GenLSP.Structures.Diagnostic{
+      data: %{"namespace" => "elixir", "type" => "require"},
+      message: "you must require Logger before invoking the macro Logger.info/1",
+      source: "Elixir",
+      range: %GenLSP.Structures.Range{
+        start: start,
+        end: %{start | character: 999}
+      }
+    }
+
+    uri = "file:///home/owner/my_project/hello.ex"
+
+    assert [code_action] = Require.new(diagnostic, text, uri)
+    assert is_struct(code_action, CodeAction)
+    assert [diagnostic] == code_action.diagnostics
+    assert code_action.title =~ "Test.Require"
+
+    assert %WorkspaceEdit{
+             changes: %{
+               ^uri => [
+                 %TextEdit{
+                   new_text: "  require Logger\n",
+                   range: %Range{start: ^start, end: ^start}
+                 }
+               ]
+             }
+           } = code_action.edit
+  end
+
+  test "figures out the correct module" do
+    text =
+      String.split(
+        """
+        defmodule Test do
+          defmodule Foo do
+            def hello() do
+              IO.inspect("foo")
+            end
+          end
+
+          defmodule Require do
+            @moduledoc
+            import Test.Foo
+            alias Test.Bar
+
+            def hello() do
+              Logger.info("foo")
+            end
+          end
+        end
+        """,
+        "\n"
+      )
+
+    start = %Position{character: 0, line: 11}
+
+    diagnostic = %GenLSP.Structures.Diagnostic{
+      data: %{"namespace" => "elixir", "type" => "require"},
+      message: "you must require Logger before invoking the macro Logger.info/1",
+      source: "Elixir",
+      range: %GenLSP.Structures.Range{
+        start: start,
+        end: %{start | character: 999}
+      }
+    }
+
+    uri = "file:///home/owner/my_project/hello.ex"
+
+    assert [code_action] = Require.new(diagnostic, text, uri)
+    assert is_struct(code_action, CodeAction)
+    assert [diagnostic] == code_action.diagnostics
+    assert code_action.title =~ "Require"
+
+    assert %WorkspaceEdit{
+             changes: %{
+               ^uri => [
+                 %TextEdit{
+                   new_text: "    require Logger\n",
+                   range: %Range{start: ^start, end: ^start}
+                 }
+               ]
+             }
+           } = code_action.edit
+  end
+end

--- a/test/next_ls/extensions/elixir_extension/code_action/unused_variable_test.exs
+++ b/test/next_ls/extensions/elixir_extension/code_action/unused_variable_test.exs
@@ -9,14 +9,18 @@ defmodule NextLS.ElixirExtension.UnusedVariableTest do
   alias NextLS.ElixirExtension.CodeAction.UnusedVariable
 
   test "adds an underscore to unused variables" do
-    text = """
-    defmodule Test.Unused do
-      def hello() do
-        foo = 3
-        :world
-      end
-    end
-    """
+    text =
+      String.split(
+        """
+        defmodule Test.Unused do
+          def hello() do
+            foo = 3
+            :world
+          end
+        end
+        """,
+        "\n"
+      )
 
     start = %Position{character: 4, line: 3}
 


### PR DESCRIPTION
This adds a require code action that adds `require Module` to your module whenever a macro is used without requiring it beforehand.
It tries to insert the require after all the top level Elixir macros(moduledoc, alias, require, import).