### PR TITLE
test: fix failing tests

### DIFF
--- a/test/next_ls/document_symbol_test.exs
+++ b/test/next_ls/document_symbol_test.exs
@@ -315,7 +315,7 @@ defmodule NextLS.DocumentSymbolTest do
                      start: %GenLSP.Structures.Position{character: 2, line: 1}
                    },
                    range: %GenLSP.Structures.Range{
-                     end: %GenLSP.Structures.Position{character: 2, line: 1},
+                     end: %GenLSP.Structures.Position{character: 18, line: 1},
                      start: %GenLSP.Structures.Position{character: 2, line: 1}
                    },
                    deprecated: nil,
@@ -348,7 +348,7 @@ defmodule NextLS.DocumentSymbolTest do
                      start: %GenLSP.Structures.Position{character: 2, line: 5}
                    },
                    range: %GenLSP.Structures.Range{
-                     end: %GenLSP.Structures.Position{character: 2, line: 5},
+                     end: %GenLSP.Structures.Position{character: 18, line: 5},
                      start: %GenLSP.Structures.Position{character: 2, line: 5}
                    },
                    deprecated: nil,

--- a/test/next_ls/extensions/credo_extension_test.exs
+++ b/test/next_ls/extensions/credo_extension_test.exs
@@ -77,7 +77,7 @@ defmodule NextLS.CredoExtensionTest do
             "check" => "Elixir.Credo.Check.Warning.Dbg",
             "file" => "lib/foo.ex"
           },
-          "message" => "There should be no calls to dbg.",
+          "message" => "There should be no calls to `dbg/1`.",
           "range" => %{
             "end" => %{"character" => 999, "line" => 2},
             "start" => %{"character" => 4, "line" => 2}
@@ -115,7 +115,7 @@ defmodule NextLS.CredoExtensionTest do
             "check" => "Elixir.Credo.Check.Warning.Dbg",
             "file" => "lib/foo.ex"
           },
-          "message" => "There should be no calls to dbg.",
+          "message" => "There should be no calls to `dbg/1`.",
           "range" => %{
             "end" => %{"character" => 999, "line" => 2},
             "start" => %{"character" => 4, "line" => 2}


### PR DESCRIPTION
Fixes 2 cases of failing tests:
1) end range of one liner def was characters long as the start where I would assume it should be the characters that add up to the end, i.e `(1 level of indentation)def run, do: :ok` is 18 characters.
2) changed message format in the credo extension