### PR TITLE
fix: homebrew release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
 
   homebrew:
     name: homebrew
-    needs: [publish]
+    needs: [publish, release]
     runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new github ci job to publish next-ls to homebrew seems to be broken https://github.com/elixir-tools/next-ls/actions/runs/7997177802/job/21841392167

This should fix it.