### PR TITLE
fix(completions): imports inside blocks that generate functions

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -646,6 +646,7 @@ defmodule NextLS do
               |> then(fn
                 {:ok, ast} -> ast
                 {:error, ast, _} -> ast
+                {:error, :no_fuel_remaining} -> nil
               end)
 
             {:ok, {_, _, _, macro_env}} = Runtime.expand(runtime, ast, Path.basename(uri))


### PR DESCRIPTION
The `test/2` macro is an example of this

Closes #420
