### PR TITLE
feat: add extract variable command

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -738,7 +738,7 @@ defmodule NextLS do
   @workspace_commands %{
     "to-pipe" => {NextLS.Commands.Pipe, :to},
     "from-pipe" => {NextLS.Commands.Pipe, :from},
-    "alias-refactor" => {NextLS.Commands.Pipe, :to},
+    "alias-refactor" => {NextLS.Commands.Alias, :run},
     "extract-variable" => {NextLS.Commands.Variables, :extract}
   }
   def handle_request(

--- a/lib/next_ls/commands.ex
+++ b/lib/next_ls/commands.ex
@@ -4,7 +4,8 @@ defmodule NextLS.Commands do
   @labels %{
     "from-pipe" => "Inlined pipe",
     "to-pipe" => "Extracted to a pipe",
-    "alias-refactor" => "Refactored with an alias"
+    "alias-refactor" => "Refactored with an alias",
+    "extract-variable" => "Extracted variable to a module attribute"
   }
   @doc "Creates a label for the workspace apply struct from the command name"
   def label(command) when is_map_key(@labels, command), do: @labels[command]

--- a/lib/next_ls/helpers/ast_helpers/variables.ex
+++ b/lib/next_ls/helpers/ast_helpers/variables.ex
@@ -43,41 +43,45 @@ defmodule NextLS.ASTHelpers.Variables do
   # end
 
   @spec list_variable_references(String.t(), {integer(), integer()}) :: [{atom(), {Range.t(), Range.t()}}]
-  def list_variable_references(file, position) do
+  def list_variable_references(file, position) when is_binary(file) do
     file = File.read!(file)
 
     case NextLS.Parser.parse(file, columns: true) do
       {:ok, ast} ->
-        {_ast, %{vars: vars}} =
-          Macro.traverse(
-            ast,
-            %{vars: [], symbols: %{}, sym_ranges: [], scope: []},
-            &prewalk/2,
-            &postwalk/2
-          )
-
-        symbol =
-          Enum.find_value(vars, fn %{name: name, sym_range: range, ref_range: ref_range} ->
-            if position_in_range?(position, ref_range), do: {name, range}, else: nil
-          end)
-
-        position =
-          case symbol do
-            nil -> position
-            {_, {line.._//_, column.._//_}} -> {line, column}
-          end
-
-        Enum.reduce(vars, [], fn val, acc ->
-          if position_in_range?(position, val.sym_range) do
-            [{val.name, val.ref_range} | acc]
-          else
-            acc
-          end
-        end)
+        list_variable_references(ast, position)
 
       _error ->
         []
     end
+  end
+
+  def list_variable_references(ast, position) when is_tuple(ast) do
+    {_ast, %{vars: vars}} =
+      Macro.traverse(
+        ast,
+        %{vars: [], symbols: %{}, sym_ranges: [], scope: []},
+        &prewalk/2,
+        &postwalk/2
+      )
+
+    symbol =
+      Enum.find_value(vars, fn %{name: name, sym_range: range, ref_range: ref_range} ->
+        if position_in_range?(position, ref_range), do: {name, range}, else: nil
+      end)
+
+    position =
+      case symbol do
+        nil -> position
+        {_, {line.._//_, column.._//_}} -> {line, column}
+      end
+
+    Enum.reduce(vars, [], fn val, acc ->
+      if position_in_range?(position, val.sym_range) do
+        [{val.name, val.ref_range} | acc]
+      else
+        acc
+      end
+    end)
   end
 
   # search symbols in function and macro definition args and increase scope

--- a/lib/next_ls/helpers/edit_helpers.ex
+++ b/lib/next_ls/helpers/edit_helpers.ex
@@ -1,5 +1,7 @@
 defmodule NextLS.EditHelpers do
   @moduledoc false
+  # Having the format length to 121 would produce the least amount of churn in the case of the formatter
+  @line_length 121
 
   @doc """
   This adds indentation to all lines except the first since the LSP expects a range for edits,
@@ -37,5 +39,18 @@ defmodule NextLS.EditHelpers do
     |> Enum.at(line)
     |> then(&Regex.run(~r/^(\s*).*/, &1))
     |> List.last()
+  end
+
+  @doc """
+  Formats back the ast with the comments.
+  """
+  @spec to_string(ast :: Macro.t(), comments :: list(term)) :: String.t()
+  def to_string(ast, comments) do
+    to_algebra_opts = [comments: comments]
+
+    ast
+    |> Code.quoted_to_algebra(to_algebra_opts)
+    |> Inspect.Algebra.format(@line_length)
+    |> IO.iodata_to_binary()
   end
 end

--- a/test/next_ls/commands/variables_test.exs
+++ b/test/next_ls/commands/variables_test.exs
@@ -1,0 +1,115 @@
+defmodule NextLS.Commands.VariablesTest do
+  use ExUnit.Case, async: true
+
+  alias GenLSP.Structures.TextEdit
+  alias GenLSP.Structures.WorkspaceEdit
+  alias NextLS.Commands.Variables
+
+  describe "extract" do
+    test "works on simple variables" do
+      uri = "my_app.ex"
+
+      text =
+        String.split(
+          """
+          defmodule MyApp do
+            def to_list(map) do
+              map = %{foo: :bar}
+              Enum.to_list(map)
+            end
+          end
+          """,
+          "\n"
+        )
+
+      expected_edit =
+        String.trim("""
+        defmodule MyApp do
+          @map %{foo: :bar}
+          def to_list(map) do
+            Enum.to_list(@map)
+          end
+        end
+        """)
+
+      line = 2
+      position = %{"line" => line, "character" => 6}
+
+      assert %WorkspaceEdit{changes: %{^uri => [edit = %TextEdit{range: range}]}} =
+               Variables.extract(%{uri: uri, text: text, position: position})
+
+      assert edit.new_text == expected_edit
+      assert range.start.line == 0
+      assert range.start.character == 0
+      assert range.end.line == 5
+      assert range.end.character == 3
+    end
+
+    test "does not replace variables in other scopes" do
+      uri = "my_app.ex"
+
+      text =
+        String.split(
+          """
+          defmodule MyApp do
+            defmodule Foo do
+              def to_list(map) do
+                map = %{foo: :bar}
+                if 3 == 4 do
+                  map
+                else
+                  fn map -> map end
+                end
+
+                Enum.to_list(map)
+              end
+
+              def to_string(map) do
+                inspect(map)
+              end
+            end
+
+            defmodule Foo do
+              def to_list(map) do
+                Enum.to_list(map)
+              end
+            end
+          end
+          """,
+          "\n"
+        )
+
+      expected_edit =
+        String.trim("""
+          defmodule Foo do
+            @map %{foo: :bar}
+            def to_list(map) do
+              if 3 == 4 do
+                @map
+              else
+                fn map -> map end
+              end
+
+              Enum.to_list(@map)
+            end
+
+            def to_string(map) do
+              inspect(map)
+            end
+          end
+        """)
+
+      line = 3
+      position = %{"line" => line, "character" => 8}
+
+      assert %WorkspaceEdit{changes: %{^uri => [edit = %TextEdit{range: range}]}} =
+               Variables.extract(%{uri: uri, text: text, position: position})
+
+      assert edit.new_text == expected_edit
+      assert range.start.line == 1
+      assert range.start.character == 2
+      assert range.end.line == 16
+      assert range.end.character == 5
+    end
+  end
+end

--- a/test/next_ls/variables_test.exs
+++ b/test/next_ls/variables_test.exs
@@ -1,0 +1,83 @@
+defmodule NextLS.VariablesTest do
+  use ExUnit.Case, async: true
+
+  import GenLSP.Test
+  import NextLS.Support.Utils
+
+  @moduletag :tmp_dir
+  @moduletag root_paths: ["my_proj"]
+
+  setup %{tmp_dir: tmp_dir} do
+    File.mkdir_p!(Path.join(tmp_dir, "my_proj/lib"))
+    File.write!(Path.join(tmp_dir, "my_proj/mix.exs"), mix_exs())
+
+    cwd = Path.join(tmp_dir, "my_proj")
+
+    foo_path = Path.join(cwd, "lib/foo.ex")
+
+    foo = """
+    defmodule MyApp do
+      def to_list(map) do
+        map = %{foo: :bar}
+        Enum.to_list(map)
+      end
+    end
+    """
+
+    File.write!(foo_path, foo)
+
+    [foo: foo, foo_path: foo_path]
+  end
+
+  setup :with_lsp
+
+  setup context do
+    assert :ok == notify(context.client, %{method: "initialized", jsonrpc: "2.0", params: %{}})
+    assert_is_ready(context, "my_proj")
+    assert_compiled(context, "my_proj")
+    assert_notification "$/progress", %{"value" => %{"kind" => "end", "message" => "Finished indexing!"}}
+
+    did_open(context.client, context.foo_path, context.foo)
+    context
+  end
+
+  test "extracts variables to module attributes", %{client: client, foo_path: foo} do
+    foo_uri = uri(foo)
+    id = 1
+
+    request client, %{
+      method: "workspace/executeCommand",
+      id: id,
+      jsonrpc: "2.0",
+      params: %{
+        command: "extract-variable",
+        arguments: [%{uri: foo_uri, position: %{line: 2, character: 8}}]
+      }
+    }
+
+    expected_edit =
+      String.trim("""
+      defmodule MyApp do
+        @map %{foo: :bar}
+        def to_list(map) do
+          Enum.to_list(@map)
+        end
+      end
+      """)
+
+    assert_request(client, "workspace/applyEdit", 500, fn params ->
+      assert %{"edit" => edit, "label" => "Extracted variable to a module attribute"} = params
+
+      assert %{
+               "changes" => %{
+                 ^foo_uri => [%{"newText" => text, "range" => range}]
+               }
+             } = edit
+
+      assert text == expected_edit
+
+      assert range["start"] == %{"character" => 0, "line" => 0}
+      assert range["end"] == %{"character" => 3, "line" => 5}
+    end)
+  end
+end


### PR DESCRIPTION
Searches the AST for an expression of the type:
`variable = expression` where the cursor can be anywhere in the expression.
Moves the variable as a module attribute and any other references of this variable are refactored as well. Afterwards it removes the assignment expression.