### PR TITLE
fix: ensure some elixir internals are ready

### DIFF
--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -1032,14 +1032,13 @@ defmodule :_next_ls_private_compiler do
   @moduledoc false
 
   def start do
+    Code.put_compiler_option(:parser_options, columns: true, token_metadata: true)
+
     children = [
       :_next_ls_private_compiler_worker
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: :_next_ls_private_application_supervisor]
-    {:ok, pid} = Supervisor.start_link(children, opts)
+    {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one, name: :_next_ls_private_application_supervisor)
     Process.unlink(pid)
     {:ok, pid}
   end
@@ -1049,7 +1048,6 @@ defmodule :_next_ls_private_compiler do
   def compile do
     # keep stdout on this node
     Process.group_leader(self(), Process.whereis(:user))
-    Code.put_compiler_option(:parser_options, columns: true, token_metadata: true)
 
     Code.put_compiler_option(:tracers, [NextLSPrivate.DepTracer | @tracers])
 


### PR DESCRIPTION
Frequently we'd see the following error in tests, and some users were
seeing in production:

```
[error] Bad RPC call to node nextls-runtime-1715431446385794000@MacBook-XXX: {:EXIT, {:badarg, [{:ets, :lookup, [:elixir_config, :parser_options], [error_info: %{cause: :id, module: :erl_stdlib_errors}]}, {:elixir_config, :get, 1, [file: ~c"src/elixir_config.erl", line: 21]}, {:elixir_compiler, :string, 3, [file: ~c"src/elixir_compiler.erl", line: 7]}, {Module.ParallelChecker, :verify, 1, [file: ~c"lib/module/parallel_checker.ex", line: 112]}, {Code, :compile_file, 1, []}]}}
```

I believe that this is caused by an internal ETS table not being booted
yet, so we not await on it being present on the project node.

Closes #467
