### PR TITLE
fix(index): better heuristic if a reference is from a macro

### DIFF
--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -128,7 +128,14 @@ defmodule NextLSPrivate.Tracer do
   def trace({type, meta, module, func, arity}, env) when type in [:remote_function, :remote_macro, :imported_macro] do
     parent = parent_pid()
 
-    if type == :remote_macro && meta[:closing][:line] != meta[:line] do
+    condition =
+      if Version.match?(System.version(), ">= 1.17.0-dev") do
+        is_nil(meta[:column])
+      else
+        type == :remote_macro && meta[:closing][:line] != meta[:line]
+      end
+
+    if condition do
       # this is the case that a macro is getting expanded from inside
       # another macro expansion
       :noop


### PR DESCRIPTION
In Elixir >= 1.17, the meta will _not_ have a `:column` key if it is
generated by a macro.
