### PR TITLE
fix: better completions for function references

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -159,7 +159,7 @@ defmodule NextLS do
          completion_provider:
            if init_opts.experimental.completions.enable do
              %GenLSP.Structures.CompletionOptions{
-               trigger_characters: [".", "@", "&", "%", "^", ":", "!", "-", "~", "/", "{"],
+               trigger_characters: [".", "@", "%", "^", ":", "!", "-", "~", "/", "{"],
                resolve_provider: true
              }
            end,

--- a/lib/next_ls/autocomplete.ex
+++ b/lib/next_ls/autocomplete.ex
@@ -72,7 +72,7 @@ defmodule NextLS.Autocomplete do
         hint = List.to_string(local_or_var)
 
         expand_container_context(code, :expr, hint, runtime, env) ||
-          expand_local_or_var(hint, List.to_string(local_or_var), runtime, env)
+          expand_local_or_var(hint, hint, runtime, env)
 
       {:local_arity, local} ->
         expand_local(List.to_string(local), true, runtime, env)


### PR DESCRIPTION
Removes `&` as a trigger character, which will allow completions to
trigger as normal once you start typing after.

This shouldn't be a problem as the only two completions offered by that
are `&` and `&&`, and operators like `||` don't complete anyway.
