### PR TITLE
fix(runtime): use correct archive locations (e.g. Hex) for bundled Elixir

### DIFF
--- a/lib/next_ls.ex
+++ b/lib/next_ls.ex
@@ -77,7 +77,8 @@ defmodule NextLS do
         :extensions,
         :registry,
         :bundle_base,
-        :mix_home
+        :mix_home,
+        :mix_archives
       ])
 
     GenLSP.start_link(__MODULE__, args, opts)
@@ -90,6 +91,7 @@ defmodule NextLS do
     dynamic_supervisor = Keyword.fetch!(args, :dynamic_supervisor)
     bundle_base = Keyword.get(args, :bundle_base, Path.expand("~/.cache/elixir-tools/nextls"))
     mix_home = Keyword.get(args, :mix_home)
+    mix_archives = Keyword.get(args, :mix_archives)
 
     registry = Keyword.fetch!(args, :registry)
 
@@ -104,6 +106,7 @@ defmodule NextLS do
        auto_update: Keyword.get(args, :auto_update, false),
        bundle_base: bundle_base,
        mix_home: mix_home,
+       mix_archives: mix_archives,
        exit_code: 1,
        documents: %{},
        refresh_refs: %{},
@@ -143,6 +146,11 @@ defmodule NextLS do
     mix_home =
       if init_opts.experimental.completions.enable do
         BundledElixir.mix_home(lsp.assigns.bundle_base)
+      end
+
+    mix_archives =
+      if init_opts.experimental.completions.enable do
+        BundledElixir.mix_archives(lsp.assigns.bundle_base)
       end
 
     {:reply,
@@ -187,6 +195,7 @@ defmodule NextLS do
      },
      assign(lsp,
        mix_home: mix_home,
+       mix_archives: mix_archives,
        root_uri: root_uri,
        workspace_folders: workspace_folders,
        client_capabilities: caps,
@@ -938,6 +947,7 @@ defmodule NextLS do
              mix_env: lsp.assigns.init_opts.mix_env,
              mix_target: lsp.assigns.init_opts.mix_target,
              mix_home: lsp.assigns.mix_home,
+             mix_archives: lsp.assigns.mix_archives,
              elixir_bin_path: elixir_bin_path,
              on_initialized: fn status ->
                if status == :ready do
@@ -1061,6 +1071,7 @@ defmodule NextLS do
               mix_env: lsp.assigns.init_opts.mix_env,
               mix_target: lsp.assigns.init_opts.mix_target,
               mix_home: lsp.assigns.mix_home,
+              mix_archives: lsp.assigns.mix_archives,
               on_initialized: fn status ->
                 if status == :ready do
                   Progress.stop(lsp, token, "NextLS runtime for folder #{name} has initialized!")

--- a/lib/next_ls/runtime.ex
+++ b/lib/next_ls/runtime.ex
@@ -112,6 +112,7 @@ defmodule NextLS.Runtime do
     mix_target = Keyword.fetch!(opts, :mix_target)
     elixir_bin_path = Keyword.get(opts, :elixir_bin_path)
     mix_home = Keyword.get(opts, :mix_home)
+    mix_archives = Keyword.get(opts, :mix_archives)
 
     elixir_exe = Path.join(elixir_bin_path, "elixir")
 
@@ -157,6 +158,11 @@ defmodule NextLS.Runtime do
           ] ++
             if mix_home do
               [{~c"MIX_HOME", ~c"#{mix_home}"}]
+            else
+              []
+            end ++
+            if mix_archives do
+              [{~c"MIX_ARCHIVES", ~c"#{mix_archives}"}]
             else
               []
             end

--- a/lib/next_ls/runtime/bundled_elixir.ex
+++ b/lib/next_ls/runtime/bundled_elixir.ex
@@ -24,8 +24,13 @@ defmodule NextLS.Runtime.BundledElixir do
     Path.join(path(base), ".mix")
   end
 
+  def mix_archives(base) do
+    Path.join(mix_home(base), "archives")
+  end
+
   def install(base, logger) do
     mixhome = mix_home(base)
+    mixarchives = mix_archives(base)
     File.mkdir_p!(mixhome)
     binpath = binpath(base)
 
@@ -45,12 +50,10 @@ defmodule NextLS.Runtime.BundledElixir do
 
     new_path = "#{binpath}:#{System.get_env("PATH")}"
     mixbin = mixpath(base)
+    env = [{"PATH", new_path}, {"MIX_HOME", mixhome}, {"MIX_ARCHIVES", mixarchives}]
 
-    {_, 0} =
-      System.cmd(mixbin, ["local.rebar", "--force"], env: [{"PATH", new_path}, {"MIX_HOME", mixhome}])
-
-    {_, 0} =
-      System.cmd(mixbin, ["local.hex", "--force"], env: [{"PATH", new_path}, {"MIX_HOME", mixhome}])
+    {_, 0} = System.cmd(mixbin, ["local.rebar", "--force"], env: env)
+    {_, 0} = System.cmd(mixbin, ["local.hex", "--force"], env: env)
 
     :ok
   rescue

--- a/test/next_ls/autocomplete_test.exs
+++ b/test/next_ls/autocomplete_test.exs
@@ -74,6 +74,7 @@ defmodule NextLS.AutocompleteTest do
          mix_env: "dev",
          mix_target: "host",
          mix_home: Path.join(cwd, ".mix"),
+         mix_archives: Path.join(cwd, [".mix", "archives"]),
          registry: __MODULE__.Registry}
       )
 

--- a/test/next_ls/runtime_test.exs
+++ b/test/next_ls/runtime_test.exs
@@ -66,6 +66,7 @@ defmodule NextLs.RuntimeTest do
            mix_env: "dev",
            mix_target: "host",
            mix_home: Path.join(cwd, ".mix"),
+           mix_archives: Path.join(cwd, [".mix", "archives"]),
            registry: RuntimeTest.Registry}
         )
 
@@ -97,6 +98,7 @@ defmodule NextLs.RuntimeTest do
            mix_env: "dev",
            mix_target: "host",
            mix_home: Path.join(cwd, ".mix"),
+           mix_archives: Path.join(cwd, [".mix", "archives"]),
            registry: RuntimeTest.Registry}
         )
 
@@ -129,6 +131,7 @@ defmodule NextLs.RuntimeTest do
            mix_env: "dev",
            mix_target: "host",
            mix_home: Path.join(cwd, ".mix"),
+           mix_archives: Path.join(cwd, [".mix", "archives"]),
            registry: RuntimeTest.Registry}
         )
 
@@ -194,6 +197,7 @@ defmodule NextLs.RuntimeTest do
            mix_env: "dev",
            mix_target: "host",
            mix_home: Path.join(cwd, ".mix"),
+           mix_archives: Path.join(cwd, [".mix", "archives"]),
            registry: RuntimeTest.Registry}
         )
 

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -46,6 +46,7 @@ defmodule NextLS.Support.Utils do
 
     bundle_base = Path.join(tmp_dir, ".bundled")
     mixhome = Path.join(tmp_dir, ".mix")
+    mixarchives = Path.join(mixhome, "archives")
     File.mkdir_p!(bundle_base)
 
     tvisor = start_supervised!(Supervisor.child_spec(Task.Supervisor, id: :one))
@@ -73,7 +74,8 @@ defmodule NextLS.Support.Utils do
         extensions: extensions,
         cache: cache,
         bundle_base: bundle_base,
-        mix_home: mixhome
+        mix_home: mixhome,
+        mix_archives: mixarchives
       )
 
     Process.link(server.lsp)


### PR DESCRIPTION
Set `MIX_ARCHIVES` explicitly to make sure to override any existing setting, e.g. from `asdf` or `mise`.

What happens on `main` currently is that `hex` is installed into whatever the environment variable `MIX_ARCHIVES` points at. The var is set by e.g. `mise`. So if the "regular" project setup is running on Elixir < 1.17, its installation of Hex will be overridden by NextLS and it stops working after that.

This patch makes sure to set `MIX_ARCHIVES` explicitly so the `hex` archive ends up in the right place.
