### PR TITLE
chore(nix): updates to use nixpkgs elixir 1.17

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718160348,
-        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
         "type": "github"
       },
       "original": {

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  beamPackages,
+  elixir,
+}:
+
+beamPackages.mixRelease rec {
+  pname = "next-ls";
+  src = ./.;
+  mixEnv = "prod";
+  removeCookie = false;
+  version = "0.23.0"; # x-release-please-version
+
+  inherit elixir;
+  inherit (beamPackages) erlang;
+
+  mixFodDeps = beamPackages.fetchMixDeps {
+    inherit src version elixir;
+    pname = "next-ls-deps";
+    hash = "sha256-4Rt5Q0fX+fbncvxyXdpIhgEvn9VYX/QDxDdnbanT21Q=";
+    mixEnv = "prod";
+  };
+
+  installPhase = ''
+    mix release --no-deps-check --path $out plain
+    echo "$out/bin/plain eval \"System.no_halt(true); Application.ensure_all_started(:next_ls)\" \"\$@\"" > "$out/bin/nextls"
+    chmod +x "$out/bin/nextls"
+  '';
+
+  meta = with lib; {
+    license = licenses.mit;
+    homepage = "https://www.elixir-tools.dev/next-ls/";
+    description = "The language server for Elixir that just works";
+    mainProgram = "nextls";
+  };
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
       "include-component-in-tag": false,
       "draft": true,
       "extra-files": [
-        "flake.nix"
+        "package.nix"
       ]
     }
   }


### PR DESCRIPTION
I split the package out here, and dropped the makeOverridable. I can put this back if needed, but I think separating the package makes it clearer to reason about. It's also more similar to a nixpkgs package this way. :)

I discovered that erlang_27 actually depends on erlang_26 currently for ex_doc, so you have to compile both with beam_minimal. Anybody using your cache won't notice though.

I also wondered if the zig pinned release could be removed in favor of current unstable.