### PR TITLE
chore(nix): update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "lastModified": 1720418205,
+        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "rev": "655a58a72a6601292512670343087c2d75d859c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,7 @@
       lib.genAttrs systems (system: let
         pkgs = nixpkgs.legacyPackages.${system};
         zpkgs = zigpkgs.legacyPackages.${system};
-        beamPackages = pkgs.beam_minimal.packages.erlang_27.extend (final: prev: {
-          elixir = final.elixir_1_17;
-          # This will get upstreamed into nix-beam-flakes at some point
-          rebar = prev.rebar.overrideAttrs (_old: {doCheck = false;});
-          rebar3 = prev.rebar3.overrideAttrs (_old: {doCheck = false;});
-        });
+        beamPackages = pkgs.beam_minimal.packages.erlang_27;
         elixir = beamPackages.elixir_1_17;
       in
         f {inherit system pkgs zpkgs beamPackages elixir;});


### PR DESCRIPTION
Updates the rev of nixpkgs and removes the overrides we discussed before. I submitted next-ls to nixpkgs, so users can install it directly from there now. As a side effect though, beam_minimal erlang_27+elixir_1_17 is now built by hydra and is thus cached. As long as the nixpkgs versions continue to match what is expected here, we shouldn't need to build the dependencies.

https://github.com/NixOS/nixpkgs/pull/324678
