### PR TITLE
fix: extract module line from debug info on 1.18

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,11 @@
         zpkgs = zigpkgs.legacyPackages.${system};
         beamPackages = pkgs.beam_minimal.packages.erlang_27;
         elixir = beamPackages.elixir_1_17;
+        # example of overriding elixir with whatever you want
+        # elixir = beamPackages.elixir_1_18.override {
+        #   rev = "f16fb5aa8162794616a738fc6e84bfcdf9892cff";
+        #   sha256 = "sha256-UYWsmih+0z+4tdPhxl2zf+4gUNEgRJR4yyvxVBOgJdQ=";
+        # };
       in
         f {inherit system pkgs zpkgs beamPackages elixir;});
 
@@ -42,7 +47,7 @@
       elixir,
       ...
     }: {
-      default = pkgs.callPackage ./package.nix { inherit beamPackages elixir; };
+      default = pkgs.callPackage ./package.nix {inherit beamPackages elixir;};
     });
 
     devShells = forAllSystems ({

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -137,7 +137,7 @@ defmodule NextLSPrivate.Tracer do
     parent = parent_pid()
 
     condition =
-      if Version.match?(System.version(), ">= 1.17.0-dev") do
+      if Version.match?(System.version(), ">= 1.17.0") do
         is_nil(meta[:column])
       else
         type == :remote_macro && meta[:closing][:line] != meta[:line]

--- a/priv/monkey/_next_ls_private_compiler.ex
+++ b/priv/monkey/_next_ls_private_compiler.ex
@@ -132,7 +132,8 @@ defmodule NextLSPrivate.Tracer do
     :ok
   end
 
-  def trace({type, meta, module, func, arity}, env) when type in [:remote_function, :remote_macro, :imported_macro] do
+  def trace({type, meta, module, func, arity}, env)
+      when type in [:remote_function, :remote_macro, :imported_macro, :imported_function] do
     parent = parent_pid()
 
     condition =
@@ -208,6 +209,7 @@ defmodule NextLSPrivate.Tracer do
         {:debug_info_v1, _, {_, %{line: line, struct: struct}, _}} ->
           {line, struct}
       end
+
     Process.send(
       parent,
       {:tracer,


### PR DESCRIPTION
fix: correctly index imported functions on 1.18

chore: change 1.17.0-dev to 1.17.0

chore(nix): update flake
